### PR TITLE
fix: disable auto linkify inside message editor

### DIFF
--- a/src/rules/links.js
+++ b/src/rules/links.js
@@ -2,7 +2,9 @@ import { inputRules } from 'prosemirror-inputrules';
 import { createInputRule } from '../utils';
 import LinkifyIt from 'linkify-it';
 
-const linkify = LinkifyIt();
+// This is a copy of the linkify-it regex, passing `undefined` for the schema
+// will use the default regex.
+const linkify = new LinkifyIt(undefined, { fuzzyLink: false });
 linkify.add('sourcetree:', 'http:');
 
 const tlds =

--- a/src/schema/markdown/messageParser.js
+++ b/src/schema/markdown/messageParser.js
@@ -26,7 +26,7 @@ export const messageMdToPmMapping = {
 
 const md = MarkdownIt('zero', {
   html: false,
-  linkify: true,
+  linkify: false,
 });
 
 md.enable([


### PR DESCRIPTION
**Why**

The fuzzy links like `github.com` were getting transformed into `[github.com](http://github.com)` by the editor which was transforming the variables `contact.name` since regex works positive in both cases.