### PR TITLE
fix: Fixes parsing issue in editor when links are inserted

### DIFF
--- a/src/keymap.js
+++ b/src/keymap.js
@@ -77,7 +77,12 @@ export function baseKeyMaps(schema) {
   if (schema.nodes.hard_break) {
     let br = schema.nodes.hard_break,
       cmd = chainCommands(exitCode, (state, dispatch) => {
-        dispatch(state.tr.replaceSelectionWith(br.create()).scrollIntoView());
+        dispatch(
+          state.tr
+            .insertText(` `)
+            .replaceSelectionWith(br.create())
+            .scrollIntoView()
+        );
         return true;
       });
     bind('Mod-Enter', cmd);


### PR DESCRIPTION
**Why was this happening** 
`\` is how markdown breaks the line. When we break the line directly at the end of a link, it'll append `\` at the end. This was causing confusion while we were parsing from Markdown to HTML in message bubbles.

**The fix**
When inserting line breaks, we are adding `[space]` before the slash to avoid confusion while it's being parsed 

**Test cases and video**
https://www.loom.com/share/44f3925ddb954a45a13c1580792a6f25