### PR TITLE
fixes: Editor adding slash char while creating block quotes

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -171,7 +171,11 @@ export const moveLeft = () => {
 
 export const insertBlock = (state, nodeType, nodeName, start, end, attrs) => {
   // To ensure that match is done after HardBreak.
-  const { hardBreak, codeBlock, listItem } = state.schema.nodes;
+  const {
+    hard_break: hardBreak,
+    code_block: codeBlock,
+    list_item: listItem,
+  } = state.schema.nodes;
   const $pos = state.doc.resolve(start);
   if ($pos.nodeAfter.type !== hardBreak) {
     return null;


### PR DESCRIPTION
**Why**

This was because of an error in the code. the `nodes` object was coming with different keys.

**Loom**
https://www.loom.com/share/82d8beba08de49f5b2405783ce2d3d0b