### PR TITLE
fix: Use double space to render hard breaks [cw-1505]

### DIFF
--- a/src/schema/markdown/messageParser.js
+++ b/src/schema/markdown/messageParser.js
@@ -24,7 +24,7 @@ export const messageMdToPmMapping = {
   },
 };
 
-const md = MarkdownIt('zero', {
+const md = MarkdownIt('commonmark', {
   html: false,
   linkify: false,
 });

--- a/src/schema/markdown/serializer.js
+++ b/src/schema/markdown/serializer.js
@@ -65,7 +65,7 @@ export const hard_break = (state, node, parent, index) => {
     }
 };
 export const text = (state, node) => {
-  state.text(node.text);
+  state.text(node.text, false);
 };
 
 export const em = {

--- a/src/schema/markdown/serializer.js
+++ b/src/schema/markdown/serializer.js
@@ -60,7 +60,7 @@ export const image = (state, node) => {
 export const hard_break = (state, node, parent, index) => {
   for (let i = index + 1; i < parent.childCount; i++)
     if (parent.child(i).type !== node.type) {
-      state.write('\\\n');
+      state.write('  ');
       return;
     }
 };

--- a/src/schema/markdown/serializer.js
+++ b/src/schema/markdown/serializer.js
@@ -105,6 +105,7 @@ export const link = {
           (mark.attrs.title ? ' ' + state.quote(mark.attrs.title) : '') +
           ')';
   },
+  escape: false,
 };
 export const code = {
   open(_state, _mark, parent, index) {


### PR DESCRIPTION
Fixes the 
Slash coming in between links and between blockquotes.

https://www.loom.com/share/8c51fdd60e094acd838a7f486594cbca

https://linear.app/chatwoot/issue/CW-1505/editor-adds-a-stray-/-in-a-conversation
https://linear.app/chatwoot/issue/CW-1526/issues-with-escaping-characters