### PR TITLE
chore: Disable superscript menu item

### DIFF
--- a/src/menu/article.js
+++ b/src/menu/article.js
@@ -230,13 +230,7 @@ export function buildArticleEditorMenu(schema, onFileUpload) {
   let cut = arr => arr.filter(x => x);
 
   r.inlineMenu = [
-    cut([
-      r.toggleStrong,
-      r.toggleEm,
-      r.toggleCode,
-      r.toggleLink,
-      r.toggleSuper,
-    ]),
+    cut([r.toggleStrong, r.toggleEm, r.toggleCode, r.toggleLink]),
   ];
   r.blockMenu = [
     cut([


### PR DESCRIPTION
Disables superscript icon inside article editor.

<img width="885" alt="image" src="https://github.com/chatwoot/prosemirror-schema/assets/1277421/27259a52-b274-4ef4-9652-32d63d824cc7">
