### PR TITLE
feat: Uses /n for hardbreaks in markdown

### DIFF
--- a/src/schema/markdown/serializer.js
+++ b/src/schema/markdown/serializer.js
@@ -60,7 +60,7 @@ export const image = (state, node) => {
 export const hard_break = (state, node, parent, index) => {
   for (let i = index + 1; i < parent.childCount; i++)
     if (parent.child(i).type !== node.type) {
-      state.write('  ');
+      state.write('  \n');
       return;
     }
 };


### PR DESCRIPTION
This will fix the bug mentioned in https://linear.app/chatwoot/issue/CW-1505/editor-adds-a-stray-/-in-a-conversation

https://github.com/chatwoot/prosemirror-schema/assets/1277421/d4c3b11d-546a-4afa-8760-9b8e6ef08fe4

