### PR TITLE
chore: Update the order of plugins

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,7 @@ export const buildEditor = ({
   plugins = [],
   enabledMenuOptions,
 }) => [
+  ...(plugins || []),
   history(),
   baseKeyMaps(schema),
   blocksInputRule(schema),
@@ -54,5 +55,4 @@ export const buildEditor = ({
       attributes: { class: "ProseMirror-woot-style" },
     },
   }),
-  ...(plugins || []),
 ];


### PR DESCRIPTION
Put plugins at the top to avoid native plugin overwriting the behaviour.