### PR TITLE
fix: Disables hr for message schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatwoot/prosemirror-schema",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Schema setup for using prosemirror in chatwoot. Based on 👉 https://github.com/ProseMirror/prosemirror-example-setup/",
   "main": "dist/index.js",
   "scripts": {

--- a/src/schema/markdown/messageParser.js
+++ b/src/schema/markdown/messageParser.js
@@ -36,6 +36,8 @@ md.enable([
   'escape',
 ]);
 
+md.disable(['table', 'hr']);
+
 export class MessageMarkdownTransformer {
   constructor(schema, tokenizer = md) {
     // Enable markdown plugins based on schema


### PR DESCRIPTION
Fixes for 
https://linear.app/chatwoot/issue/CW-2918/error-token-type-hr-not-supported-by-markdown-parser
https://linear.app/chatwoot/issue/CW-2928/error-token-type-heading-open-not-supported-by-markdown-parser