### PR TITLE
fix: Remove heading token from message parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatwoot/prosemirror-schema",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Schema setup for using prosemirror in chatwoot. Based on 👉 https://github.com/ProseMirror/prosemirror-example-setup/",
   "main": "dist/index.js",
   "scripts": {

--- a/src/schema/markdown/messageParser.js
+++ b/src/schema/markdown/messageParser.js
@@ -36,7 +36,7 @@ md.enable([
   'escape',
 ]);
 
-md.disable(['table', 'hr']);
+md.disable(['table', 'hr', 'heading']);
 
 export class MessageMarkdownTransformer {
   constructor(schema, tokenizer = md) {


### PR DESCRIPTION
fixes error reported in https://chatwoot-p3.sentry.io/issues/4769664667/?project=6382945

**The error**

From the trace, the value sent to the editor has underlines which is rendered as heading by markdown. But headings are not supported in our message parser.

```
Currently the following showrooms are open
===============
Banani Branch - Every Day - 11 AM to 9 PM
Baily Road Branch - Every Day - 11 AM to 9 PM (Thursday Close) 

Store locations https://www.banglashoppers.com/locations
```

