### PR TITLE
fix: Remove support for lheading rule in message editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatwoot/prosemirror-schema",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Schema setup for using prosemirror in chatwoot. Based on 👉 https://github.com/ProseMirror/prosemirror-example-setup/",
   "main": "dist/index.js",
   "scripts": {

--- a/src/schema/markdown/messageParser.js
+++ b/src/schema/markdown/messageParser.js
@@ -36,7 +36,7 @@ md.enable([
   'escape',
 ]);
 
-md.disable(['table', 'hr', 'heading']);
+md.disable(['table', 'hr', 'heading', 'lheading'], true);
 
 export class MessageMarkdownTransformer {
   constructor(schema, tokenizer = md) {


### PR DESCRIPTION
Fixes for a case missed here

https://github.com/markdown-it/markdown-it/blob/master/benchmark/samples/block-lheading.md

https://linear.app/chatwoot/issue/CW-2918/error-token-type-hr-not-supported-by-markdown-parser
https://linear.app/chatwoot/issue/CW-2928/error-token-type-heading-open-not-supported-by-markdown-parser