### PR TITLE
chore: Version upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatwoot/prosemirror-schema",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Schema setup for using prosemirror in chatwoot. Based on 👉 https://github.com/ProseMirror/prosemirror-example-setup/",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
**This version upgrade will add the following changes** 
Remove `heading token` and `lheading` rule in the message editor https://github.com/chatwoot/prosemirror-schema/pull/24 https://github.com/chatwoot/prosemirror-schema/pull/25 .
This change is not published yet, which will fix this [issue](https://github.com/chatwoot/chatwoot/issues/9557) 