### PR TITLE
fix: Remove backslash after hard breaks before `--`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatwoot/prosemirror-schema",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Schema setup for using prosemirror in chatwoot. Based on 👉 https://github.com/ProseMirror/prosemirror-example-setup/",
   "main": "dist/index.es.js",
   "scripts": {

--- a/src/schema/markdown/serializer.js
+++ b/src/schema/markdown/serializer.js
@@ -5,8 +5,8 @@ const MARKDOWN_PATTERNS = {
   // CommonMark list markers: "* ", "- ", "+ " or "1. ", "1) " (up to 9 digits)
   list: /^([*\-+]|\d{1,9}[.)])\s/,
   // Block-level markdown syntax that should not be preceded by backslash
-  // Includes: blockquote (>), ATX headings (#), fenced code (``` or ~~~), thematic breaks (---, ***, ___)
-  blockStart: /^(>\s?|#{1,6}\s|```|~~~|[-*_]{3,}$)/,
+  // Includes: blockquote (>), ATX headings (#), fenced code (``` or ~~~), thematic breaks (--, ---, ***, ___)
+  blockStart: /^(>\s?|#{1,6}\s|```|~~~|[-*_]{2,}$)/,
 };
 
 /**


### PR DESCRIPTION

### **PR Description**

This PR fixes an issue where an unwanted backslash (`\`) appeared after a hard break (`Shift+Enter`) when the next line started with `--`.

**How to reproduce**

1. Type some text
2. Press `Shift + Enter`
3. Start the next line with `--`.
4. A backslash appears before the new line

**Root cause**
The markdown detector only handled sequences of **3 or more** special characters (`---`).
Double characters (`--`) were treated as normal text, causing the hard-break serializer to insert a backslash.

**Solution**
Updated the block start regex to detect **2 or more** consecutive special characters, preventing the extra backslash.


### Screenshots

**Before**
<img width="205" height="86" alt="image" src="https://github.com/user-attachments/assets/05fd8067-cc88-4290-addb-c8332d9929cf" />

**After**
<img width="205" height="86" alt="image" src="https://github.com/user-attachments/assets/75600e5c-92ec-496d-949b-b8d627ac38ef" />
