### PR TITLE
fix: Use native dialog element for prompt modals

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatwoot/prosemirror-schema",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "Schema setup for using prosemirror in chatwoot. Based on 👉 https://github.com/ProseMirror/prosemirror-example-setup/",
   "main": "dist/index.es.js",
   "scripts": {

--- a/src/prompt.js
+++ b/src/prompt.js
@@ -34,19 +34,34 @@ function getValues(fields, domFields) {
 }
 
 export function openPrompt(options) {
-  let wrapper = document.body.appendChild(document.createElement('div'));
+  // Use a native <dialog> element so it renders in the browser's top layer,
+  // automatically appearing above everything including other open dialogs.
+  let dialog = document.createElement('dialog');
+  dialog.className = prefix + '-backdrop';
+
+  // Create the prompt wrapper (the visible dialog box)
+  let wrapper = document.createElement('div');
   wrapper.className = prefix;
+  dialog.appendChild(wrapper);
+
+  document.body.appendChild(dialog);
+  dialog.showModal();
 
   const close = () => {
-    // eslint-disable-next-line no-use-before-define
-    window.removeEventListener('mousedown', mouseOutside);
-    if (wrapper.parentNode) wrapper.parentNode.removeChild(wrapper);
+    if (dialog.open) dialog.close();
+    if (dialog.parentNode) dialog.parentNode.removeChild(dialog);
   };
 
-  let mouseOutside = e => {
-    if (!wrapper.contains(e.target)) close();
-  };
-  setTimeout(() => window.addEventListener('mousedown', mouseOutside), 50);
+  // Close when clicking the backdrop (outside the wrapper)
+  dialog.addEventListener('mousedown', e => {
+    if (e.target === dialog) close();
+  });
+
+  // Handle native cancel event (e.g. Escape key)
+  dialog.addEventListener('cancel', e => {
+    e.preventDefault();
+    close();
+  });
 
   let domFields = [];
 
@@ -77,10 +92,6 @@ export function openPrompt(options) {
   buttons.appendChild(submitButton);
   buttons.appendChild(document.createTextNode(' '));
   buttons.appendChild(cancelButton);
-
-  let box = wrapper.getBoundingClientRect();
-  wrapper.style.top = (window.innerHeight - box.height) / 2 + 'px';
-  wrapper.style.left = (window.innerWidth - box.width) / 2 + 'px';
 
   let submit = () => {
     let params = getValues(options.fields, domFields);

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -137,9 +137,20 @@ li.ProseMirror-selectednode:after {
   display: block;
 }
 
+.ProseMirror-prompt-backdrop {
+  border: none;
+  padding: 0;
+  background: transparent;
+  max-width: none;
+  max-height: none;
+  overflow: visible;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .ProseMirror-prompt {
-  position: fixed;
-  z-index: 11;
+  position: relative;
   padding: var(--space-normal);
   background: white;
 }


### PR DESCRIPTION
This PR replace custom positioning and backdrop logic with native `<dialog>` element. This ensures prompts render in the browser's top layer, automatically appearing above all other content including existing dialogs. Simplify click-outside and escape key handling using native dialog events.

### Screenshots

**Before**
<img width="2292" height="1178" alt="image" src="https://github.com/user-attachments/assets/c9179df0-a295-4046-8c19-18d8ef198f4f" />




**After**
<img width="2292" height="1178" alt="Screenshot 2026-03-05 at 6 06 18 PM" src="https://github.com/user-attachments/assets/b5aff237-2b25-4dcd-af2c-3cb6f3fd1284" />
