### PR TITLE
feat: Add autoLinkURLs plugin to convert bare URLs into links on paste

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatwoot/prosemirror-schema",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "Schema setup for using prosemirror in chatwoot. Based on 👉 https://github.com/ProseMirror/prosemirror-example-setup/",
   "main": "dist/index.es.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ import {
   textFormattingInputRules,
 } from "./rules/index";
 import buildMenuOptions from "./menu/menuOptions";
+import { autoLinkURLs } from "./plugins/autoLink";
 
 export { EditorState, Selection } from "prosemirror-state";
 export { EditorView } from "prosemirror-view";
@@ -42,6 +43,7 @@ export const buildEditor = ({
     blocksInputRule(schema),
     textFormattingInputRules(schema),
     linksInputRules(schema),
+    autoLinkURLs(schema),
     hrInputRules(schema),
     listInputRules(schema),
     dropCursor(),

--- a/src/plugins/autoLink.js
+++ b/src/plugins/autoLink.js
@@ -1,0 +1,100 @@
+import { Plugin } from "prosemirror-state";
+import { Slice, Fragment } from "prosemirror-model";
+import { linkify, normalizeUrl } from "../rules/links";
+
+/**
+ * Takes a slice of pasted content and returns a new slice with link
+ * marks applied to any bare URLs found in text nodes.
+ */
+function linkifySlice(slice, schema) {
+  const linkMarkType = schema.marks.link;
+  if (!linkMarkType) return slice;
+
+  const fragment = linkifyFragment(slice.content, schema, linkMarkType, null);
+  return new Slice(fragment, slice.openStart, slice.openEnd);
+}
+
+/**
+ * Recursively walks a fragment and applies link marks to bare URLs
+ * in text nodes.
+ */
+function linkifyFragment(fragment, schema, linkMarkType, parentNode) {
+  const nodes = [];
+
+  fragment.forEach(node => {
+    if (node.isText) {
+      nodes.push(...linkifyTextNode(node, schema, linkMarkType, parentNode));
+    } else if (node.content.size > 0) {
+      nodes.push(node.copy(linkifyFragment(node.content, schema, linkMarkType, node)));
+    } else {
+      nodes.push(node);
+    }
+  });
+
+  return Fragment.fromArray(nodes);
+}
+
+/**
+ * Takes a text node and splits it into multiple nodes where bare URLs
+ * get a link mark applied. Returns an array of nodes.
+ */
+function linkifyTextNode(node, schema, linkMarkType, parentNode) {
+  if (parentNode && !parentNode.type.allowsMarkType(linkMarkType)) return [node];
+
+  // Skip if already has a link mark
+  if (linkMarkType.isInSet(node.marks)) return [node];
+
+  const matches = linkify.match(node.text);
+  if (!matches || matches.length === 0) return [node];
+
+  const nodes = [];
+  let lastIndex = 0;
+
+  matches.forEach(match => {
+    const url = normalizeUrl(match.url);
+    if (!url) return;
+
+    // Text before the URL
+    if (match.index > lastIndex) {
+      nodes.push(schema.text(node.text.slice(lastIndex, match.index), node.marks));
+    }
+
+    // The URL with link mark
+    const linkMark = linkMarkType.create({ href: url });
+    nodes.push(
+      schema.text(
+        node.text.slice(match.index, match.lastIndex),
+        linkMark.addToSet(node.marks)
+      )
+    );
+
+    lastIndex = match.lastIndex;
+  });
+
+  // Remaining text after last URL
+  if (lastIndex < node.text.length) {
+    nodes.push(schema.text(node.text.slice(lastIndex), node.marks));
+  }
+
+  return nodes;
+}
+
+/**
+ * ProseMirror plugin that automatically converts bare URLs into
+ * proper link marks in pasted content.
+ *
+ * Typed URLs are handled by the existing linksInputRules (on space).
+ * This plugin covers the paste case where URLs would otherwise
+ * remain as plain text.
+ */
+export function autoLinkURLs(schema) {
+  if (!schema.marks.link) return null;
+
+  return new Plugin({
+    props: {
+      transformPasted(slice) {
+        return linkifySlice(slice, schema);
+      },
+    },
+  });
+}

--- a/src/rules/links.js
+++ b/src/rules/links.js
@@ -4,7 +4,7 @@ import LinkifyIt from 'linkify-it';
 
 // This is a copy of the linkify-it regex, passing `undefined` for the schema
 // will use the default regex.
-const linkify = new LinkifyIt(undefined, { fuzzyLink: false });
+export const linkify = new LinkifyIt(undefined, { fuzzyLink: false });
 linkify.add('sourcetree:', 'http:');
 
 const tlds =


### PR DESCRIPTION

## PR Description

This PR improves URL auto-linking in the editor.

Previously, URLs were only linkified after a user input event (e.g., typing a space). With this change, URLs are now automatically linkified immediately on paste.

### What changed

* Added paste handling using `transformPasted` to auto-linkify URLs on paste.
* Recursively processes pasted content and applies link marks to bare URLs.
* Added schema safety:
  * Link marks are applied only if the parent node allows them.
* Existing behavior for already-linked text and non-URL text remains unchanged.

### Why

* By default, ProseMirror applies transformations like autolinking via input rules, which are triggered only on input events (e.g., space/enter), not on paste.
* ProseMirror provides `transformPasted` specifically to modify pasted content before it is inserted into the document. 
