### PR TITLE
fix: encode parentheses in link hrefs during markdown serialization

### DIFF
--- a/src/schema/markdown/serializer.js
+++ b/src/schema/markdown/serializer.js
@@ -221,7 +221,7 @@ export const link = {
     return isPlainURL(mark, parent, index, -1)
       ? '>'
       : '](' +
-          state.esc(mark.attrs.href).replace(/\)/g, '%29') +
+          state.esc(mark.attrs.href).replace(/\(/g, '%28').replace(/\)/g, '%29') +
           (mark.attrs.title ? ' ' + state.quote(mark.attrs.title) : '') +
           ')';
   },

--- a/src/schema/markdown/serializer.js
+++ b/src/schema/markdown/serializer.js
@@ -221,7 +221,7 @@ export const link = {
     return isPlainURL(mark, parent, index, -1)
       ? '>'
       : '](' +
-          state.esc(mark.attrs.href) +
+          state.esc(mark.attrs.href).replace(/\)/g, '%29') +
           (mark.attrs.title ? ' ' + state.quote(mark.attrs.title) : '') +
           ')';
   },


### PR DESCRIPTION
## Problem

When a link's `href` contains literal `(` or `)` characters (e.g. URLs with
[Text Fragments](https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Fragment/Text_fragments)
like `#:~:text=3.1) some text`), the markdown serializer produces broken output:

```
[link text](https://example.com/page/#:~:text=3.1) some text after paren)
```

The CommonMark parser treats the first `)` as the closing delimiter of `[text](url)`,
so the rest of the URL becomes plain (percent-encoded) text visible to the reader.

Text Fragments are generated automatically by Chrome when the user copies a link
to selected text on a page. The fragment can contain `(` or `)` as part of the
highlighted text, so this is a real-world scenario users encounter regularly.

## Root Cause

In `src/schema/markdown/serializer.js`, the `close` handler for the `link` mark
uses `state.esc(href)` which only escapes markdown-special characters
(`\`, `` ` ``, `*`, `~`, `[`, `]`, `_`) but does **not** encode `(` or `)`,
which are the delimiters of a CommonMark inline link.

## Fix

Encode `(` as `%28` and `)` as `%29` in the href before inserting it into the markdown string:

```js
// before
state.esc(mark.attrs.href)

// after
state.esc(mark.attrs.href).replace(/\(/g, '%28').replace(/\)/g, '%29')
```

This is consistent with how `prosemirror-markdown` handles parentheses
in image `src` attributes:
```js
// prosemirror-markdown/src/to_markdown.ts
node.attrs.src.replace(/[\(\)]/g, "\\$&")
```

`%28` and `%29` are the standard percent-encodings for `(` and `)` and are
universally supported by browsers — the link remains fully functional.

## Affected Versions

Reproduced in all versions including the latest `1.3.7`.