### PR TITLE
feat: add embed-preview and trailing-paragraph plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 
 # ignore dist
 dist
+.zed/settings.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatwoot/prosemirror-schema",
-  "version": "1.3.10",
+  "version": "1.3.11-alpha",
   "description": "Schema setup for using prosemirror in chatwoot. Based on 👉 https://github.com/ProseMirror/prosemirror-example-setup/",
   "main": "dist/index.es.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatwoot/prosemirror-schema",
-  "version": "1.3.11-alpha",
+  "version": "1.3.11",
   "description": "Schema setup for using prosemirror in chatwoot. Based on 👉 https://github.com/ProseMirror/prosemirror-example-setup/",
   "main": "dist/index.es.js",
   "scripts": {

--- a/src/mentions/plugin.js
+++ b/src/mentions/plugin.js
@@ -14,6 +14,11 @@ import { Decoration, DecorationSet } from 'prosemirror-view';
  * @returns {Function} A function that takes a position object and returns the match if the condition is met.
  */
 export const triggerCharacters = (char, minChars = 0) => $position => {
+  // Bail when the position has no enclosing textblock to look into (e.g. a
+  // NodeSelection on a top-level block, gap cursor, or AllSelection). Calling
+  // $position.before() at depth 0 throws "no position before the top-level node".
+  if ($position.depth === 0) return null;
+
   // Regular expression to find occurrences of 'char' followed by at least 'minChars' non-space characters.
   // It matches these sequences starting from the beginning of the text or after a space.
   const regexp = new RegExp(`(?:^)?${char}[^\\s${char}]{${minChars},}`, 'g');

--- a/src/plugins/embedPreview.js
+++ b/src/plugins/embedPreview.js
@@ -42,6 +42,15 @@ const buildEmbedWidget = html => () => {
   wrapper.className = "cw-embed-preview";
   wrapper.contentEditable = "false";
   wrapper.innerHTML = html;
+  // innerHTML doesn't execute <script> tags — re-create them so they do.
+  wrapper.querySelectorAll("script").forEach(stale => {
+    const fresh = document.createElement("script");
+    Array.from(stale.attributes).forEach(({ name, value }) =>
+      fresh.setAttribute(name, value)
+    );
+    fresh.textContent = stale.textContent;
+    stale.replaceWith(fresh);
+  });
   return wrapper;
 };
 

--- a/src/plugins/embedPreview.js
+++ b/src/plugins/embedPreview.js
@@ -1,0 +1,129 @@
+import { Plugin, PluginKey, TextSelection } from "prosemirror-state";
+import { Decoration, DecorationSet } from "prosemirror-view";
+
+const isTopLevelTextSelection = selection =>
+  selection instanceof TextSelection &&
+  selection.empty &&
+  selection.$from.depth === 1;
+
+const getLoneLinkUrl = paragraph => {
+  if (paragraph.type.name !== "paragraph") return null;
+  let url = null;
+  for (let i = 0; i < paragraph.childCount; i += 1) {
+    const child = paragraph.child(i);
+    if (!child.isText) return null;
+    const linkMark = child.marks.find(mark => mark.type.name === "link");
+    if (linkMark) {
+      if (url && url !== linkMark.attrs.href) return null;
+      url = linkMark.attrs.href;
+    } else if (child.text.trim() !== "") {
+      return null;
+    }
+  }
+  return url;
+};
+
+const renderTemplate = (template, captures) =>
+  Object.entries(captures).reduce(
+    (html, [name, value]) => html.replaceAll(`%{${name}}`, value),
+    template
+  );
+
+const findEmbedHtml = (embeds, url) => {
+  for (const { regex, template } of embeds) {
+    const match = url.match(regex);
+    if (match) return renderTemplate(template, match.groups || {});
+  }
+  return null;
+};
+
+const buildEmbedWidget = html => () => {
+  const wrapper = document.createElement("div");
+  wrapper.className = "cw-embed-preview";
+  wrapper.contentEditable = "false";
+  wrapper.innerHTML = html;
+  return wrapper;
+};
+
+const collectEmbeds = (doc, embeds) => {
+  const items = [];
+  doc.forEach((node, offset, index) => {
+    const url = getLoneLinkUrl(node);
+    if (!url) return;
+    const html = findEmbedHtml(embeds, url);
+    if (!html) return;
+    items.push({ index, offset, nodeSize: node.nodeSize, url, html });
+  });
+  return items;
+};
+
+const buildSet = (doc, items) =>
+  DecorationSet.create(
+    doc,
+    items.map(item =>
+      Decoration.widget(
+        item.offset + item.nodeSize,
+        buildEmbedWidget(item.html),
+        { side: -1, key: `embed:${item.url}` }
+      )
+    )
+  );
+
+const signatureOf = items =>
+  items.map(item => `${item.index}:${item.url}`).join("|");
+
+const insertParagraphAfterEmbed = (state, dispatch, embeds) => {
+  if (!isTopLevelTextSelection(state.selection)) return false;
+  const { schema } = state;
+  const { $from } = state.selection;
+  const paragraph = $from.parent;
+  if (paragraph.type.name !== "paragraph") return false;
+  if ($from.parentOffset !== paragraph.content.size) return false;
+  const url = getLoneLinkUrl(paragraph);
+  if (!url || !findEmbedHtml(embeds, url)) return false;
+  if (dispatch) {
+    const insertPos = $from.after();
+    const tr = state.tr.insert(insertPos, schema.nodes.paragraph.create());
+    tr.setSelection(TextSelection.create(tr.doc, insertPos + 1));
+    dispatch(tr.scrollIntoView());
+  }
+  return true;
+};
+
+export const embedPreviewKey = new PluginKey("embedPreview");
+
+export default function embedPreviewPlugin(embeds = []) {
+  return new Plugin({
+    key: embedPreviewKey,
+    state: {
+      init(_, { doc }) {
+        const items = collectEmbeds(doc, embeds);
+        return { set: buildSet(doc, items), signature: signatureOf(items) };
+      },
+      apply(tr, old) {
+        if (!tr.docChanged) return old;
+        const items = collectEmbeds(tr.doc, embeds);
+        const signature = signatureOf(items);
+        if (signature === old.signature) {
+          return { set: old.set.map(tr.mapping, tr.doc), signature };
+        }
+        return { set: buildSet(tr.doc, items), signature };
+      },
+    },
+    props: {
+      decorations(state) {
+        return embedPreviewKey.getState(state).set;
+      },
+      handleKeyDown(view, event) {
+        if (event.key !== "Enter") return false;
+        if (event.shiftKey || event.metaKey || event.ctrlKey || event.altKey)
+          return false;
+        return insertParagraphAfterEmbed(
+          view.state,
+          tr => view.dispatch(tr),
+          embeds
+        );
+      },
+    },
+  });
+}

--- a/src/plugins/trailingParagraph.js
+++ b/src/plugins/trailingParagraph.js
@@ -1,0 +1,23 @@
+import { Plugin } from "prosemirror-state";
+
+/**
+ * Ensures the document always ends with a paragraph.
+ *
+ * Without this, blocks that don't yield a "next position" on their own
+ * (tables, atomic block images, custom embeds, etc.) leave the user with no
+ * place to land the caret below them. Mirrors the standard "trailing node"
+ * pattern (e.g. Tiptap's TrailingNode extension).
+ */
+export default function trailingParagraphPlugin() {
+  return new Plugin({
+    appendTransaction(transactions, _oldState, newState) {
+      if (!transactions.some(tr => tr.docChanged)) return null;
+      const { doc, schema } = newState;
+      const paragraphType = schema.nodes.paragraph;
+      if (!paragraphType) return null;
+      const last = doc.lastChild;
+      if (!last || last.type === paragraphType) return null;
+      return newState.tr.insert(doc.content.size, paragraphType.create());
+    },
+  });
+}


### PR DESCRIPTION

**Description**

This PR includes two new editor improvements

**What’s new**

* **Embed preview**
  Automatically shows a preview (like an iframe) when a paragraph contains only a supported link
  * Stays stable while typing elsewhere
  * Pressing Enter creates a new paragraph after the preview, avoiding extra empty lines

* **Trailing paragraph**
  Ensures there is always an empty paragraph at the end
  * Fixes cases where the cursor gets stuck after tables, images, or embeds