### PR TITLE
feat: support drag-to-resize for message editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatwoot/prosemirror-schema",
-  "version": "1.3.15",
+  "version": "1.3.16",
   "description": "Schema setup for using prosemirror in chatwoot. Based on 👉 https://github.com/ProseMirror/prosemirror-example-setup/",
   "main": "dist/index.es.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatwoot/prosemirror-schema",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "description": "Schema setup for using prosemirror in chatwoot. Based on 👉 https://github.com/ProseMirror/prosemirror-example-setup/",
   "main": "dist/index.es.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatwoot/prosemirror-schema",
-  "version": "1.3.16",
+  "version": "1.3.17",
   "description": "Schema setup for using prosemirror in chatwoot. Based on 👉 https://github.com/ProseMirror/prosemirror-example-setup/",
   "main": "dist/index.es.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatwoot/prosemirror-schema",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "description": "Schema setup for using prosemirror in chatwoot. Based on 👉 https://github.com/ProseMirror/prosemirror-example-setup/",
   "main": "dist/index.es.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ import {
 import buildMenuOptions from "./menu/menuOptions";
 import { autoLinkURLs } from "./plugins/autoLink";
 import { tableControlsPlugin } from "./plugins/table";
+import isolateImagesPlugin from "./plugins/isolateImages";
 
 export { EditorState, Selection } from "prosemirror-state";
 export { EditorView } from "prosemirror-view";
@@ -54,6 +55,8 @@ export const buildEditor = ({
     gapCursor(),
     schema.nodes.table ? tableEditing() : null,
     schema.nodes.table ? tableControlsPlugin(schema) : null,
+    // Message editors (image, no table): keep each image alone on its line.
+    schema.nodes.image && !schema.nodes.table ? isolateImagesPlugin() : null,
     Placeholder(placeholder),
     menuBar({
       floating: true,

--- a/src/index.js
+++ b/src/index.js
@@ -55,8 +55,8 @@ export const buildEditor = ({
     gapCursor(),
     schema.nodes.table ? tableEditing() : null,
     schema.nodes.table ? tableControlsPlugin(schema) : null,
-    // Message editors (image, no table): keep each image alone on its line.
-    schema.nodes.image && !schema.nodes.table ? isolateImagesPlugin() : null,
+    // editor with images (messages and articles): keep each image alone on its line.
+    schema.nodes.image ? isolateImagesPlugin() : null,
     Placeholder(placeholder),
     menuBar({
       floating: true,

--- a/src/keymap.js
+++ b/src/keymap.js
@@ -101,7 +101,7 @@ export function baseKeyMaps(schema) {
     selectNodeBackward,
   ];
   // Message editors (image, no table): let Backspace clear an image above.
-  if (schema.nodes.image && !schema.nodes.table) {
+  if (schema.nodes.image) {
     backspaceList.unshift(deleteImageBackward);
   }
   const backspaceComands = chainCommands(...backspaceList);

--- a/src/keymap.js
+++ b/src/keymap.js
@@ -46,6 +46,28 @@ import { keymap } from 'prosemirror-keymap';
 const mac =
   typeof navigator !== 'undefined' ? /Mac/.test(navigator.platform) : false;
 
+// A paragraph whose only content is an image.
+const isImageParagraph = node =>
+  !!node &&
+  node.type.name === 'paragraph' &&
+  node.childCount === 1 &&
+  node.firstChild.type.name === 'image';
+
+// Backspace at the start of a line whose previous block is an image-only
+// paragraph clears that image. The image-isolation plugin keeps images alone on
+// their line, which would otherwise make the default join a silent no-op.
+function deleteImageBackward(state, dispatch) {
+  const { $cursor } = state.selection;
+  if (!$cursor || $cursor.parentOffset !== 0) return false;
+  const prev = state.doc.resolve($cursor.before()).nodeBefore;
+  if (!isImageParagraph(prev)) return false;
+  if (dispatch) {
+    const to = $cursor.before();
+    dispatch(state.tr.delete(to - prev.nodeSize, to).scrollIntoView());
+  }
+  return true;
+}
+
 // Find the table node at the given depth from $from, or -1
 function findTableDepth($from, tableType) {
   for (let d = $from.depth; d > 0; d--) {
@@ -71,13 +93,18 @@ export function baseKeyMaps(schema) {
 
   bind('Mod-z', chainCommands(undoInputRule, undo));
   bind('Shift-Mod-z', redo);
-  const backspaceComands = chainCommands(
+  const backspaceList = [
     undoInputRule,
     cleanUpAtTheStartOfDocument,
     deleteSelection,
     joinBackward,
-    selectNodeBackward
-  );
+    selectNodeBackward,
+  ];
+  // Message editors (image, no table): let Backspace clear an image above.
+  if (schema.nodes.image && !schema.nodes.table) {
+    backspaceList.unshift(deleteImageBackward);
+  }
+  const backspaceComands = chainCommands(...backspaceList);
   bind('Backspace', backspaceComands);
   bind('Mod-Backspace', backspaceComands);
 
@@ -288,7 +315,7 @@ export function baseKeyMaps(schema) {
     // Currently Mod+enter command is never reached as it is overridden at the editor
     //  side with Cmd+Enter for sending messages.
     // Fix this by using a different keymap or overriding existing keymap on condition.
-    
+
     enterCommands.unshift(splitListItem(schema.nodes.list_item));
 
     if (schema.nodes.table) {

--- a/src/nodeViews/imageResize.js
+++ b/src/nodeViews/imageResize.js
@@ -38,6 +38,11 @@ class ImageResizeView {
     event.preventDefault();
     const containerWidth = this.dom.parentElement?.clientWidth;
     if (!containerWidth) return;
+    // In RTL the handle sits on the bottom-LEFT corner (via inset-inline-end),
+    // so outward motion is a NEGATIVE clientX delta. Flip the X contribution
+    // so dragging in the direction the icon points always grows the image.
+    const isRtl = getComputedStyle(this.dom).direction === 'rtl';
+    const xSign = isRtl ? -1 : 1;
     const startW = this.dom.getBoundingClientRect().width;
     const startX = event.clientX;
     const startY = event.clientY;
@@ -46,7 +51,7 @@ class ImageResizeView {
 
     const onMove = e => {
       moved = true;
-      const px = startW + (e.clientX - startX) + (e.clientY - startY);
+      const px = startW + xSign * (e.clientX - startX) + (e.clientY - startY);
       widthPx = Math.max(MIN_PX, Math.min(containerWidth, Math.round(px)));
       this.dom.style.width = `${widthPx}px`;
     };

--- a/src/plugins/isolateImages.js
+++ b/src/plugins/isolateImages.js
@@ -1,4 +1,52 @@
-import { Plugin } from "prosemirror-state";
+import { EditorState, Plugin } from "prosemirror-state";
+
+/**
+ * Positions at which paragraphs must be split so that every image ends up alone
+ * in its own paragraph (no text to its left or right). Returned deduped and
+ * sorted descending so callers can apply them without remapping earlier
+ * positions. (Adjacent images share a boundary, hence the dedupe.)
+ *
+ * @param {Node} doc - The ProseMirror document to inspect.
+ * @returns {number[]} - Split positions, sorted high → low.
+ */
+function imageIsolationSplits(doc) {
+  const splits = [];
+  doc.descendants((node, pos) => {
+    if (node.type.name !== "paragraph" || node.childCount < 2) return;
+
+    const contentStart = pos + 1;
+    const contentEnd = pos + node.nodeSize - 1;
+
+    node.forEach((child, offset) => {
+      if (child.type.name !== "image") return;
+      const imageStart = contentStart + offset;
+      const imageEnd = imageStart + child.nodeSize;
+      if (imageStart > contentStart) splits.push(imageStart);
+      if (imageEnd < contentEnd) splits.push(imageEnd);
+    });
+  });
+
+  return [...new Set(splits)].sort((a, b) => b - a);
+}
+
+/**
+ * Normalizes a document so every image sits alone in its own paragraph. Apply
+ * at parse time so freshly parsed markdown matches the editor's runtime layout
+ * (and therefore serializes back to identical markdown). Without this, a
+ * parse → serialize round-trip keeps images inline while the live editor
+ * isolates them, so the two outputs diverge.
+ *
+ * @param {Node} doc - The ProseMirror document to normalize.
+ * @returns {Node} - The document with images isolated (unchanged if none apply).
+ */
+export function isolateImagesInDoc(doc) {
+  const splits = imageIsolationSplits(doc);
+  if (!splits.length) return doc;
+
+  const { tr } = EditorState.create({ doc });
+  splits.forEach(p => tr.split(p));
+  return tr.doc;
+}
 
 /**
  * Keeps every image on its own line — no text to its left or right.
@@ -13,28 +61,11 @@ export default function isolateImagesPlugin() {
     appendTransaction(transactions, _oldState, newState) {
       if (!transactions.some(tr => tr.docChanged)) return null;
 
-      const splits = [];
-      newState.doc.descendants((node, pos) => {
-        if (node.type.name !== "paragraph" || node.childCount < 2) return;
-
-        const contentStart = pos + 1;
-        const contentEnd = pos + node.nodeSize - 1;
-
-        node.forEach((child, offset) => {
-          if (child.type.name !== "image") return;
-          const imageStart = contentStart + offset;
-          const imageEnd = imageStart + child.nodeSize;
-          if (imageStart > contentStart) splits.push(imageStart);
-          if (imageEnd < contentEnd) splits.push(imageEnd);
-        });
-      });
-
+      const splits = imageIsolationSplits(newState.doc);
       if (!splits.length) return null;
 
       const tr = newState.tr;
-      // Dedupe (adjacent images share a boundary) and apply from the end so
-      // earlier positions stay valid.
-      [...new Set(splits)].sort((a, b) => b - a).forEach(p => tr.split(p));
+      splits.forEach(p => tr.split(p));
       return tr;
     },
   });

--- a/src/plugins/isolateImages.js
+++ b/src/plugins/isolateImages.js
@@ -1,0 +1,41 @@
+import { Plugin } from "prosemirror-state";
+
+/**
+ * Keeps every image on its own line — no text to its left or right.
+ *
+ * The image node is inline, so ProseMirror would otherwise let text share the
+ * paragraph. After each change, this splits any paragraph that holds an image
+ * alongside other content, so the image ends up alone in its own paragraph.
+ * (Backspace-to-clear an image is handled in the keymap, not here.)
+ */
+export default function isolateImagesPlugin() {
+  return new Plugin({
+    appendTransaction(transactions, _oldState, newState) {
+      if (!transactions.some(tr => tr.docChanged)) return null;
+
+      const splits = [];
+      newState.doc.descendants((node, pos) => {
+        if (node.type.name !== "paragraph" || node.childCount < 2) return;
+
+        const contentStart = pos + 1;
+        const contentEnd = pos + node.nodeSize - 1;
+
+        node.forEach((child, offset) => {
+          if (child.type.name !== "image") return;
+          const imageStart = contentStart + offset;
+          const imageEnd = imageStart + child.nodeSize;
+          if (imageStart > contentStart) splits.push(imageStart);
+          if (imageEnd < contentEnd) splits.push(imageEnd);
+        });
+      });
+
+      if (!splits.length) return null;
+
+      const tr = newState.tr;
+      // Dedupe (adjacent images share a boundary) and apply from the end so
+      // earlier positions stay valid.
+      [...new Set(splits)].sort((a, b) => b - a).forEach(p => tr.split(p));
+      return tr;
+    },
+  });
+}

--- a/src/schema/markdown/articleParser.js
+++ b/src/schema/markdown/articleParser.js
@@ -7,6 +7,7 @@ import {
   baseMarksMdToPmMapping,
   filterMdToPmSchemaMapping,
 } from './parser';
+import { isolateImagesInDoc } from '../../plugins/isolateImages';
 
 export const articleSchemaToMdMapping = {
   nodes: {
@@ -101,6 +102,8 @@ export class ArticleMarkdownTransformer {
   }
 
   parse(content) {
-    return this.markdownParser.parse(content);
+    // Isolate images the same way the live editor does (isolateImagesPlugin),
+    // so a parse → serialize round-trip matches the editor's output.
+    return isolateImagesInDoc(this.markdownParser.parse(content));
   }
 }

--- a/src/schema/markdown/messageParser.js
+++ b/src/schema/markdown/messageParser.js
@@ -6,6 +6,7 @@ import {
   baseMarksMdToPmMapping,
   filterMdToPmSchemaMapping,
 } from './parser';
+import { isolateImagesInDoc } from '../../plugins/isolateImages';
 
 export const messageSchemaToMdMapping = {
   nodes: { ...baseSchemaToMdMapping.nodes },
@@ -69,6 +70,8 @@ export class MessageMarkdownTransformer {
   }
 
   parse(content) {
-    return this.markdownParser.parse(content);
+    // Isolate images the same way the live editor does (isolateImagesPlugin),
+    // so a parse → serialize round-trip matches the editor's output.
+    return isolateImagesInDoc(this.markdownParser.parse(content));
   }
 }

--- a/src/schema/message.js
+++ b/src/schema/message.js
@@ -15,7 +15,8 @@ export const messageSchema = new Schema({
       ...schema.spec.nodes.get('image'),
       attrs: {
         ...schema.spec.nodes.get('image').attrs,
-        height: {default: null}
+        height: {default: null},
+        width: {default: null}
       },
       parseDOM: [{
         tag: 'img[src]',
@@ -23,21 +24,20 @@ export const messageSchema = new Schema({
           src: dom.getAttribute('src'),
           title: dom.getAttribute('title'),
           alt: dom.getAttribute('alt'),
-          height: parseInt(dom.style.height)
+          height: parseInt(dom.style.height) || null,
+          width: dom.style.width || null
         })
       }],
       toDOM: node => {
-        const attrs = {
-          src: node.attrs.src,
-          alt: node.attrs.alt,
-          height: node.attrs.height
-        };
-        if (node.attrs.height) {
+        const attrs = { src: node.attrs.src, alt: node.attrs.alt };
+        if (node.attrs.width) {
+          attrs.style = `width: ${node.attrs.width}; max-width: 100%; height: auto`;
+        } else if (node.attrs.height) {
           attrs.style = `height: ${node.attrs.height}`;
         }
         return ["img", attrs];
       }
-    }, 
+    },
     ordered_list: Object.assign(orderedList, {
       content: 'list_item+',
       group: 'block',
@@ -48,8 +48,8 @@ export const messageSchema = new Schema({
     }),
     list_item: Object.assign(listItem, { content: 'paragraph block*' }),
     mention: {
-      attrs: { 
-        userFullName: { default: '' }, 
+      attrs: {
+        userFullName: { default: '' },
         userId: { default: '' },
         mentionType: { default: 'user' }
       },
@@ -75,7 +75,7 @@ export const messageSchema = new Schema({
             const userId = dom.getAttribute('mention-user-id');
             const userFullName = dom.getAttribute('mention-user-full-name');
             const mentionType = dom.getAttribute('mention-type') || 'user';
-            
+
             return { userId, userFullName, mentionType };
           },
         },

--- a/src/schema/schemaBuilder.js
+++ b/src/schema/schemaBuilder.js
@@ -5,7 +5,7 @@ import { schema as baseSchema } from 'prosemirror-markdown';
 /**
  * Build a schema with only specified marks and nodes enabled
  * This controls keyboard shortcuts, paste, input rules, and menu
- * 
+ *
  * @param {Array<string>} enabledMarks - Array of mark names to allow
  * @param {Array<string>} enabledNodes - Array of node names to allow (e.g., ['bulletList', 'orderedList'])
  * @returns {Schema}
@@ -13,7 +13,7 @@ import { schema as baseSchema } from 'prosemirror-markdown';
 export function buildMessageSchema(enabledMarks = ['strong', 'em', 'code', 'link'], enabledNodes = ['bulletList', 'orderedList']) {
   // Build marks string for nodes (space-separated mark names)
   const marksString = enabledMarks.length > 0 ? enabledMarks.join(' ') : '';
-  
+
   // Check which nodes are enabled
   const hasBulletList = enabledNodes.includes('bulletList');
   const hasOrderedList = enabledNodes.includes('orderedList');
@@ -47,7 +47,8 @@ export function buildMessageSchema(enabledMarks = ['strong', 'em', 'code', 'link
         ...baseSchema.spec.nodes.get('image'),
         attrs: {
           ...baseSchema.spec.nodes.get('image').attrs,
-          height: { default: null }
+          height: { default: null },
+          width: { default: null }
         },
         parseDOM: [{
           tag: 'img[src]',
@@ -55,16 +56,15 @@ export function buildMessageSchema(enabledMarks = ['strong', 'em', 'code', 'link
             src: dom.getAttribute('src'),
             title: dom.getAttribute('title'),
             alt: dom.getAttribute('alt'),
-            height: parseInt(dom.style.height)
+            height: parseInt(dom.style.height) || null,
+            width: dom.style.width || null
           })
         }],
         toDOM: node => {
-          const attrs = {
-            src: node.attrs.src,
-            alt: node.attrs.alt,
-            height: node.attrs.height
-          };
-          if (node.attrs.height) {
+          const attrs = { src: node.attrs.src, alt: node.attrs.alt };
+          if (node.attrs.width) {
+            attrs.style = `width: ${node.attrs.width}; max-width: 100%; height: auto`;
+          } else if (node.attrs.height) {
             attrs.style = `height: ${node.attrs.height}`;
           }
           return ["img", attrs];
@@ -92,8 +92,8 @@ export function buildMessageSchema(enabledMarks = ['strong', 'em', 'code', 'link
       }),
     } : {}),
     mention: {
-      attrs: { 
-        userFullName: { default: '' }, 
+      attrs: {
+        userFullName: { default: '' },
         userId: { default: '' },
         mentionType: { default: 'user' }
       },
@@ -155,23 +155,23 @@ export function buildMessageSchema(enabledMarks = ['strong', 'em', 'code', 'link
 
   // Build marks object - ONLY include enabled marks
   const marks = {};
-  
+
   if (enabledMarks.includes('link')) {
     marks.link = baseSchema.spec.marks.get('link');
   }
-  
+
   if (enabledMarks.includes('em')) {
     marks.em = baseSchema.spec.marks.get('em');
   }
-  
+
   if (enabledMarks.includes('strong')) {
     marks.strong = baseSchema.spec.marks.get('strong');
   }
-  
+
   if (enabledMarks.includes('code')) {
     marks.code = baseSchema.spec.marks.get('code');
   }
-  
+
   if (enabledMarks.includes('strike')) {
     marks.strike = {
       parseDOM: [

--- a/src/styles/article.scss
+++ b/src/styles/article.scss
@@ -15,64 +15,92 @@
   }
 
   .ProseMirror {
-    p {
-      font-size: var(--font-size-medium);
-      line-height: 1.75rem;
-      margin-bottom: var(--space-medium);
-    }
+    font-size: var(--font-size-default); // 16px
+    line-height: 1.75;
 
-    strong code {
-      font-size: var(--font-size-medium);
+    p {
+      font-size: var(--font-size-default);
+      margin-top: 20px; // 1.25em — no matching --space-* var
+      margin-bottom: 20px;
     }
 
     pre code {
-      font-size: var(--font-size-default);
-      font-weight: var(--font-weight-medium);
-      line-height: 1.6;
+      font-size: inherit;
+      font-weight: inherit;
+      line-height: inherit;
     }
 
     blockquote {
-      padding-left: var(--space-normal);
-      margin: var(--space-medium) 0;
+      margin-top: 25.6px; // 1.6em — matches prose default
+      margin-bottom: 25.6px;
+      padding-inline-start: var(--space-normal);
+      font-style: italic;
     }
 
     a {
       font-weight: var(--font-weight-medium);
-      font-size: var(--font-size-medium);
+      font-size: var(--font-size-default);
     }
 
     hr {
       border-color: var(--s-100);
-      margin-bottom: var(--space-big);
+      margin-top: var(--space-larger); // 48px (~3em from prose default)
+      margin-bottom: var(--space-larger);
     }
 
     h1 {
-      font-size: var(--font-size-big);
-      font-weight: var(--font-weight-heavy);
-      margin-bottom: var(--space-medium);
+      font-size: 36px; // 2.25em (prose default; no matching --font-size-* var)
+      font-weight: 620;
+      line-height: 1.1111111;
+      margin-top: 0;
+      margin-bottom: var(--space-large); // 32px
     }
 
     h2 {
-      font-size: var(--font-size-large);
-      font-weight: var(--font-weight-black);
-      margin-bottom: var(--space-medium);
+      font-size: var(--font-size-big); // 24px (1.5em)
+      font-weight: 620;
+      line-height: 1.3333333;
+      margin-top: var(--space-large); // 32px (2em)
+      margin-bottom: var(--space-normal); // 16px (1em)
     }
 
-    h3,
+    h3 {
+      font-size: var(--font-size-large); // 20px (1.25em)
+      font-weight: 620;
+      line-height: 1.6;
+      margin-top: var(--space-medium); // 24px (~1.6em)
+      margin-bottom: var(--space-slab); // 12px (0.6em)
+    }
+
     h4 {
-      font-size: var(--font-size-medium);
-      font-weight: var(--font-weight-bold);
-      margin-bottom: var(--space-normal);
+      font-size: var(--font-size-default); // 16px
+      font-weight: 620;
+      line-height: 1.5;
+      margin-top: var(--space-medium); // 24px (1.5em)
+      margin-bottom: var(--space-small); // 8px (0.5em)
     }
 
     h5 {
-      font-size: var(--font-size-medium);
+      font-size: var(--font-size-default);
+      font-weight: 620;
+      margin-top: var(--space-normal);
       margin-bottom: var(--space-small);
     }
 
     h6 {
-      font-size: var(--font-size-medium);
+      font-size: var(--font-size-default);
+      font-weight: 620;
+      margin-top: var(--space-normal);
       margin-bottom: var(--space-smaller);
+    }
+
+    // Reset spacing on the first child so the editor doesn't start with a gap.
+    > :first-child {
+      margin-top: 0;
+    }
+
+    > :last-child {
+      margin-bottom: 0;
     }
 
     .ProseMirror-icon svg {
@@ -80,32 +108,53 @@
     }
 
     li::marker {
-      font-size: var(--font-size-medium);
+      font-size: var(--font-size-default);
     }
 
     ul,
     ol {
-      margin-top: var(--space-medium);
-      margin-bottom: var(--space-medium);
-      padding-left: var(--space-large);
+      margin-top: 20px;
+      margin-bottom: 20px;
+      padding-inline-start: 26px; // 1.625em from prose default
     }
 
+    ul, ul ul, ul ul ul { list-style-type: disc; }
+    ol, ol ol, ol ol ol { list-style-type: decimal; }
+
     li {
-      ul,
-      ol {
-        margin-top: var(--space-normal);
-        margin-bottom: var(--space-normal);
-      }
-      p {
-        padding-left: var(--space-medium);
-        margin-top: var(--space-small);
-        margin-bottom: var(--space-small);
-      }
+      margin-top: var(--space-small); // 8px (0.5em)
+      margin-bottom: var(--space-small);
+      padding-inline-start: 6px; // 0.375em
+    }
+
+    // Nested lists get tighter vertical rhythm matching prose default.
+    ul ul,
+    ul ol,
+    ol ul,
+    ol ol {
+      margin-top: var(--space-slab); // 12px (0.75em)
+      margin-bottom: var(--space-slab);
+    }
+
+    // Portal collapses li > p margins (`[&_li>p]:m-0`). Mirror that here.
+    li > p {
+      margin-top: 0;
+      margin-bottom: 0;
     }
 
     pre {
-      padding: var(--space-normal);
-      margin-bottom: var(--space-normal);
+      font-size: var(--font-size-small); // 14px (0.875em)
+      line-height: 1.7142857;
+      margin-top: var(--space-medium); // 24px (~1.71em)
+      margin-bottom: var(--space-medium);
+      padding: var(--space-slab) var(--space-normal); // ~12px 16px
+      border-radius: var(--border-radius-medium);
+    }
+
+    p code,
+    li code,
+    strong code {
+      font-size: var(--font-size-small); // 14px (0.875em)
     }
 
 

--- a/src/styles/article.scss
+++ b/src/styles/article.scss
@@ -108,45 +108,7 @@
       margin-bottom: var(--space-normal);
     }
 
-    // Image resize wrapper + diagonal handle (bottom-right corner)
-    .pm-image-wrapper {
-      position: relative;
-      display: inline-block;
-      max-width: 100%;
-      line-height: 0;
 
-      img { display: block; max-width: 100%; height: auto; }
-      // Once the user has resized (wrapper has an inline width), force the img
-      // to fill the wrapper so the corner handle stays anchored to its edge.
-      &[style*="width"] img { width: 100%; }
-
-      .pm-image-resize-handle {
-        position: absolute;
-        inset-inline-end: 8px;
-        bottom: 8px;
-        display: grid;
-        place-items: center;
-        width: 22px;
-        height: 22px;
-        color: #fff;
-        background: rgba(0, 0, 0, 0.65);
-        border-radius: 6px;
-        cursor: nwse-resize;
-        opacity: 0;
-        transition: opacity 0.12s, background 0.12s;
-
-        svg { width: 12px; height: 12px; pointer-events: none; }
-        &:hover { background: rgba(0, 0, 0, 0.8); }
-
-        [dir="rtl"] & {
-          cursor: nesw-resize;
-          svg { transform: scaleX(-1); }
-        }
-      }
-
-      &:hover .pm-image-resize-handle,
-      &.ProseMirror-selectednode .pm-image-resize-handle { opacity: 1; }
-    }
 
     // Table wrapper for horizontal scroll
     .tableWrapper {

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -282,6 +282,13 @@ li.ProseMirror-selectednode:after {
     cursor: text;
   }
 
+  // An image sits alone in its paragraph, so ProseMirror adds a trailing <br>
+  // for the caret; with the 1.4 line-height that renders a blank line below the
+  // image. Collapse it so the image sits flush (the image keeps its own height).
+  p:has(> .pm-image-wrapper) {
+    line-height: 0;
+  }
+
   // Image resize wrapper + diagonal handle (bottom-right corner). Shared by
   // every editor variant that registers the imageResizeView NodeView.
   .pm-image-wrapper {
@@ -294,6 +301,9 @@ li.ProseMirror-selectednode:after {
     // Once the user has resized (wrapper has an inline width), force the img
     // to fill the wrapper so the corner handle stays anchored to its edge.
     &[style*="width"] img { width: 100%; }
+
+    // Subtle light-blue outline on hover so the image's edges
+    &:hover { outline: 2px solid rgba(59, 130, 246, 0.5); outline-offset: -2px; }
 
     .pm-image-resize-handle {
       position: absolute;

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -209,6 +209,9 @@ li.ProseMirror-selectednode:after {
     margin-left: 0;
   }
 
+  ul, ul ul, ul ul ul { list-style-type: disc; }
+  ol, ol ol, ol ol ol { list-style-type: decimal; }
+
   li {
     position: relative;
     padding-left: var(--space-smaller);

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -281,4 +281,45 @@ li.ProseMirror-selectednode:after {
     content: attr(data-placeholder);
     cursor: text;
   }
+
+  // Image resize wrapper + diagonal handle (bottom-right corner). Shared by
+  // every editor variant that registers the imageResizeView NodeView.
+  .pm-image-wrapper {
+    position: relative;
+    display: inline-block;
+    max-width: 100%;
+    line-height: 0;
+
+    img { display: block; max-width: 100%; height: auto; }
+    // Once the user has resized (wrapper has an inline width), force the img
+    // to fill the wrapper so the corner handle stays anchored to its edge.
+    &[style*="width"] img { width: 100%; }
+
+    .pm-image-resize-handle {
+      position: absolute;
+      inset-inline-end: 8px;
+      bottom: 8px;
+      display: grid;
+      place-items: center;
+      width: 22px;
+      height: 22px;
+      color: #fff;
+      background: rgba(0, 0, 0, 0.65);
+      border-radius: 6px;
+      cursor: nwse-resize;
+      opacity: 0;
+      transition: opacity 0.12s, background 0.12s;
+
+      svg { width: 12px; height: 12px; pointer-events: none; }
+      &:hover { background: rgba(0, 0, 0, 0.8); }
+
+      [dir="rtl"] & {
+        cursor: nesw-resize;
+        svg { transform: scaleX(-1); }
+      }
+    }
+
+    &:hover .pm-image-resize-handle,
+    &.ProseMirror-selectednode .pm-image-resize-handle { opacity: 1; }
+  }
 }


### PR DESCRIPTION
### Description

1. Adds drag-to-resize for inline images in the message editors (used by the chat widget and email reply composers), matching the behavior already shipped for help center articles. The chosen size is persisted via a `cw_image_width` URL query param so it round-trips through markdown.
2. Add plugin to keep images alone on their line in message editors. Make Backspace delete an image-only paragraph when the cursor is at the start, collapse the trailing <br> spacing so images don't render a blank line below, and add a subtle hover outline for image wrappers.
3. Updated article editor typography to match published portal styling
4. Fixed heading, body text, paragraph, and list spacing inconsistencies
5. Improved WYSIWYG experience so editor output matches live article view
6. Fixed nested list markers rendering incorrectly
7. Nested unordered/ordered lists now use proper markers at each level (`disc`, `decimal`, etc.)

## Screenshots

### Before
<img width="1044" height="1088" alt="image" src="https://github.com/user-attachments/assets/5bff66f0-ad0e-497e-bbee-4b7ea6c3d7b5" />


### After
<img width="1044" height="1088" alt="image" src="https://github.com/user-attachments/assets/3bfb10d7-f734-4d85-a472-0df680729dfc" />

