### PR TITLE
chore: fix CI build by updating Node versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,15 +7,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node: ["22.x", "20.x"]
+        node: ["22.13", "24"]
         os: [ubuntu-latest]
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Use Node ${{ matrix.node }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
 


### PR DESCRIPTION
The CI build was failing because the latest pnpm (v11.3) requires Node ≥ 22.13 and depends on the `node:sqlite` built-in, which is not available in Node 20 (`ERR_UNKNOWN_BUILTIN_MODULE: node:sqlite`).
* Update Node matrix from `22.x` / `20.x` to `22.13` / `24`
* Bump `actions/checkout@v2` → `@v4`
* Bump `actions/setup-node@v1` → `@v4` (older versions run on deprecated Node 16)
