### PR TITLE
fix: encode unsafe characters in markdown link hrefs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatwoot/prosemirror-schema",
-  "version": "1.3.20",
+  "version": "1.3.21",
   "description": "Schema setup for using prosemirror in chatwoot. Based on 👉 https://github.com/ProseMirror/prosemirror-example-setup/",
   "main": "dist/index.es.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatwoot/prosemirror-schema",
-  "version": "1.3.19",
+  "version": "1.3.20",
   "description": "Schema setup for using prosemirror in chatwoot. Based on 👉 https://github.com/ProseMirror/prosemirror-example-setup/",
   "main": "dist/index.es.js",
   "scripts": {

--- a/src/schema/markdown/serializer.js
+++ b/src/schema/markdown/serializer.js
@@ -318,7 +318,13 @@ export const link = {
     return isPlainURL(mark, parent, index, -1)
       ? '>'
       : '](' +
-          state.esc(mark.attrs.href) +
+          // CommonMark link destinations cannot contain whitespace or
+          // unbalanced parens; percent-encode/escape them so the stored
+          // markdown stays parseable for any href. Paren escaping happens
+          // after esc(), which would otherwise double-escape the backslashes
+          state
+            .esc(mark.attrs.href.replace(/\s/g, encodeURIComponent))
+            .replace(/[()]/g, '\\$&') +
           (mark.attrs.title ? ' ' + state.quote(mark.attrs.title) : '') +
           ')';
   },
@@ -347,7 +353,9 @@ function backticksFor(node, side) {
 }
 
 function isPlainURL(link, parent, index, side) {
-  if (link.attrs.title || !/^\w+:/.test(link.attrs.href)) return false;
+  // `<url>` autolinks cannot contain whitespace; fall back to the
+  // []() form, which percent-encodes it
+  if (link.attrs.title || !/^\w+:/.test(link.attrs.href) || /\s/.test(link.attrs.href)) return false;
   let content = parent.child(index + (side < 0 ? -1 : 0));
   if (
     !content.isText ||

--- a/src/schema/markdown/serializer.js
+++ b/src/schema/markdown/serializer.js
@@ -210,6 +210,14 @@ const MARK_WRAPPERS = {
   link: null, // handled specially
 };
 
+// CommonMark link destinations cannot contain whitespace or unbalanced
+// parens; percent-encode/escape them so the stored markdown stays parseable
+// for any href. Paren escaping happens after esc(), which would otherwise
+// double-escape the backslashes. Shared by link.close and table cells.
+function serializeLinkHref(state, href) {
+  return state.esc(href.replace(/\s/g, encodeURIComponent)).replace(/[()]/g, '\\$&');
+}
+
 // Serialize cell inline content to a markdown string (preserves marks)
 function serializeCellContent(state, cell) {
   const parts = [];
@@ -223,7 +231,7 @@ function serializeCellContent(state, cell) {
             if (wrapper) {
               t = wrapper[0] + t + wrapper[1];
             } else if (mark.type.name === 'link' && mark.attrs.href) {
-              t = '[' + t + '](' + mark.attrs.href + ')';
+              t = '[' + t + '](' + serializeLinkHref(state, mark.attrs.href) + ')';
             }
           });
         }
@@ -337,13 +345,7 @@ export const link = {
     return isPlainURL(mark, parent, index, -1)
       ? '>'
       : '](' +
-          // CommonMark link destinations cannot contain whitespace or
-          // unbalanced parens; percent-encode/escape them so the stored
-          // markdown stays parseable for any href. Paren escaping happens
-          // after esc(), which would otherwise double-escape the backslashes
-          state
-            .esc(mark.attrs.href.replace(/\s/g, encodeURIComponent))
-            .replace(/[()]/g, '\\$&') +
+          serializeLinkHref(state, mark.attrs.href) +
           (mark.attrs.title ? ' ' + state.quote(mark.attrs.title) : '') +
           ')';
   },


### PR DESCRIPTION
**Description**

The PR fixes links with spaces or parentheses in the URL being rendered as raw markdown (`[label](url)`) after reopening the editor or on the help center.

**Cause**

The serialized markdown was invalid. CommonMark does not allow raw whitespace or unescaped parentheses inside link destinations, causing downstream renderers to fail parsing the link.

**Solution**

Percent-encode whitespace and escape parentheses when serializing hrefs. URLs with whitespace now use the standard `[label](url)` format instead of autolinks, ensuring links survive markdown serialization and rendering correctly.
