### PR TITLE
fix: allow resizing images wrapped in inline links

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatwoot/prosemirror-schema",
-  "version": "1.3.21",
+  "version": "1.3.22",
   "description": "Schema setup for using prosemirror in chatwoot. Based on 👉 https://github.com/ProseMirror/prosemirror-example-setup/",
   "main": "dist/index.es.js",
   "scripts": {

--- a/src/nodeViews/imageResize.js
+++ b/src/nodeViews/imageResize.js
@@ -36,7 +36,10 @@ class ImageResizeView {
 
   onMouseDown = event => {
     event.preventDefault();
-    const containerWidth = this.dom.parentElement?.clientWidth;
+    // Pasted images can be wrapped in an inline ancestor (e.g. a link), whose
+    // clientWidth is 0; fall back to the editor width so resize still works.
+    const containerWidth =
+      this.dom.parentElement?.clientWidth || this.view.dom.clientWidth;
     if (!containerWidth) return;
     // In RTL the handle sits on the bottom-LEFT corner (via inset-inline-end),
     // so outward motion is a NEGATIVE clientX delta. Flip the X contribution


### PR DESCRIPTION
### Description

This PR fixes an issue where pasted images could not be resized immediately after being added to the editor. In some cases, pasted images are wrapped inside an inline `<a>` element whose `clientWidth` is `0`. Since the resize logic relies on this value, it would exit early and prevent the resize handles from functioning until the editor was reloaded.

The fix introduces a fallback to the editor width (`view.dom.clientWidth`) whenever the parent element does not provide a valid width, ensuring that image resizing works correctly without requiring a page refresh.
