### PR TITLE
fix: escape embed URL captures to prevent attribute injection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatwoot/prosemirror-schema",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Schema setup for using prosemirror in chatwoot. Based on 👉 https://github.com/ProseMirror/prosemirror-example-setup/",
   "main": "dist/index.es.js",
   "scripts": {

--- a/src/plugins/embedPreview.js
+++ b/src/plugins/embedPreview.js
@@ -23,13 +23,24 @@ const getLoneLinkUrl = paragraph => {
   return url;
 };
 
+// Captures come straight from the URL and land inside attribute values, so
+// escape them before interpolation — otherwise a crafted id can break out and
+// inject attributes (e.g. a quote in a YouTube video id adding an onload).
+const escapeHtml = value =>
+  String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+
 const renderTemplate = (template, captures) =>
   Object.entries(captures).reduce(
-    (html, [name, value]) => html.replaceAll(`%{${name}}`, value),
+    (html, [name, value]) => html.replaceAll(`%{${name}}`, escapeHtml(value)),
     template
   );
 
-const findEmbedHtml = (embeds, url) => {
+export const findEmbedHtml = (embeds, url) => {
   for (const { regex, template } of embeds) {
     const match = url.match(regex);
     if (match) return renderTemplate(template, match.groups || {});

--- a/test/embedPreview.spec.js
+++ b/test/embedPreview.spec.js
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+
+import { findEmbedHtml } from '../src/plugins/embedPreview';
+
+// Mirrors the youtube entry from chatwoot's markdown_embeds.yml: the video id is
+// captured as [^&/]+, which permits quotes and spaces.
+const youtube = {
+  regex: /https?:\/\/(?:www\.)?(?:youtube\.com\/watch\?v=|youtu\.be\/)(?<video_id>[^&/]+)/,
+  template:
+    '<iframe src="https://www.youtube-nocookie.com/embed/%{video_id}"></iframe>',
+};
+const embeds = [youtube];
+
+describe('findEmbedHtml', () => {
+  it('interpolates a clean capture without altering it', () => {
+    const html = findEmbedHtml(embeds, 'https://youtube.com/watch?v=abc_123-XY');
+    expect(html).toContain('embed/abc_123-XY"');
+  });
+
+  it('returns null when no embed matches', () => {
+    expect(findEmbedHtml(embeds, 'https://example.com/not-a-video')).toBeNull();
+  });
+
+  it('escapes a capture that tries to break out of the src attribute', () => {
+    const html = findEmbedHtml(
+      embeds,
+      'https://youtube.com/watch?v=safe" onload="window.x=1'
+    );
+    // The injected quote is escaped, so no real onload attribute is created.
+    expect(html).toContain('safe&quot; onload=&quot;window.x=1');
+    expect(html).not.toContain('safe" onload=');
+  });
+
+  it('escapes angle brackets in a capture', () => {
+    const html = findEmbedHtml(embeds, 'https://youtube.com/watch?v=<script>');
+    expect(html).toContain('embed/&lt;script&gt;"');
+    expect(html).not.toContain('<script>');
+  });
+});


### PR DESCRIPTION
## Description

The embed preview generates HTML by interpolating regex capture groups from a matched URL into an embed template, which is then rendered using `innerHTML`.

Previously, these captured values were inserted without escaping. A specially crafted URL, such as a YouTube ID containing a `"`, could break out of the iframe's `src` attribute and inject additional attributes like `onload`, allowing script execution in the editor.

This change escapes all captured values (`&`, `"`, `'`, `<`, and `>`) before interpolation, ensuring they remain part of the attribute value. Valid embed IDs, which are typically alphanumeric with dashes or underscores, continue to render exactly as before.

Also adds `test/embedPreview.spec.js` to cover:

* A valid embed URL.
* A non-matching URL.
* An injection attempt to verify captured values are properly escaped.

`findEmbedHtml` is now exported so it can be tested directly.
