### PR TITLE
feat: improve upload and video embed experience

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatwoot/prosemirror-schema",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Schema setup for using prosemirror in chatwoot. Based on 👉 https://github.com/ProseMirror/prosemirror-example-setup/",
   "main": "dist/index.es.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatwoot/prosemirror-schema",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Schema setup for using prosemirror in chatwoot. Based on 👉 https://github.com/ProseMirror/prosemirror-example-setup/",
   "main": "dist/index.es.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatwoot/prosemirror-schema",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Schema setup for using prosemirror in chatwoot. Based on 👉 https://github.com/ProseMirror/prosemirror-example-setup/",
   "main": "dist/index.es.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -39,6 +39,16 @@ export { buildMessageSchema } from "./schema/schemaBuilder";
 
 export { imageResizeView } from "./nodeViews/imageResize";
 
+export { default as imagePastePlugin } from "./plugins/image";
+export { default as embedPreviewPlugin } from "./plugins/embedPreview";
+export {
+  fileUploadPlugin,
+  hasActiveUploads,
+  insertFileUploads,
+  insertImageFiles,
+} from "./plugins/uploads";
+export { setUploadLabels } from "./plugins/uploadState";
+
 export const buildEditor = ({
   schema,
   placeholder,

--- a/src/keymap.js
+++ b/src/keymap.js
@@ -29,6 +29,7 @@ import {
   joinUp,
   joinDown,
   selectParentNode,
+  selectAll,
   baseKeymap,
   deleteSelection,
   joinBackward,
@@ -116,7 +117,7 @@ export function baseKeyMaps(schema) {
 
   if (schema.nodes.table) {
     // Progressive Cmd+A: cell content → all cells → whole document
-    bind('Mod-a', (state, dispatch) => {
+    const progressiveTableSelectAll = (state, dispatch) => {
       const { $from, from, to } = state.selection;
       const tableDepth = findTableDepth($from, schema.nodes.table);
       if (tableDepth < 0) return false;
@@ -188,7 +189,10 @@ export function baseKeyMaps(schema) {
         }
       }
       return true;
-    });
+    };
+    // Outside a table the progressive command declines; fall back to the
+    // editor's select-all so the browser never selects the whole page.
+    bind('Mod-a', chainCommands(progressiveTableSelectAll, selectAll));
 
     // Backspace/Delete on CellSelection: delete selected rows, columns, or entire table
     const deleteCellSelection = (state, dispatch) => {

--- a/src/mentions/plugin.js
+++ b/src/mentions/plugin.js
@@ -21,7 +21,10 @@ export const triggerCharacters = (char, minChars = 0) => $position => {
 
   // Regular expression to find occurrences of 'char' followed by at least 'minChars' non-space characters.
   // It matches these sequences starting from the beginning of the text or after a space.
-  const regexp = new RegExp(`(?:^)?${char}[^\\s${char}]{${minChars},}`, 'g');
+  // \0 is textBetween's placeholder for non-text leaves (hard breaks, images).
+  // Treat it like whitespace, or a trigger typed before a line break swallows
+  // the break and the query never matches.
+  const regexp = new RegExp(`(?:^)?${char}[^\\s${char}\\0]{${minChars},}`, 'g');
 
   // Get the position before the current cursor position in the document.
   const textFrom = $position.before();

--- a/src/nodeViews/cornerResize.js
+++ b/src/nodeViews/cornerResize.js
@@ -36,13 +36,10 @@ const startCornerResize = (handle, event, { target, containerWidth, minPx, onCom
   }
 };
 
-const RESIZE_KEY_STEP = 16;
-
 // Shared corner chip for images and embeds. `getOptions(event)` returns the
-// resize options, or a falsy value to ignore the interaction.
+// drag options, or a falsy value to ignore the press.
 export const buildResizeHandle = (label, getOptions) => {
-  const handle = document.createElement("button");
-  handle.type = "button";
+  const handle = document.createElement("span");
   handle.className = "pm-resize-handle";
   handle.contentEditable = "false";
   handle.setAttribute("aria-label", label);
@@ -52,22 +49,6 @@ export const buildResizeHandle = (label, getOptions) => {
     event.stopPropagation();
     const options = getOptions(event);
     if (options) startCornerResize(handle, event, options);
-  });
-  // Keyboard resize: right/up grows, left/down shrinks.
-  handle.addEventListener("keydown", (event) => {
-    const grow = event.key === "ArrowRight" || event.key === "ArrowUp";
-    if (!grow && event.key !== "ArrowLeft" && event.key !== "ArrowDown") return;
-    const options = getOptions(event);
-    if (!options) return;
-    event.preventDefault();
-    event.stopPropagation();
-    const { target, containerWidth, minPx, onCommit } = options;
-    const width =
-      Math.round(target.getBoundingClientRect().width) +
-      (grow ? RESIZE_KEY_STEP : -RESIZE_KEY_STEP);
-    const widthPx = Math.max(minPx, Math.min(containerWidth, width));
-    target.style.width = `${widthPx}px`;
-    onCommit(widthPx);
   });
   return handle;
 };

--- a/src/nodeViews/cornerResize.js
+++ b/src/nodeViews/cornerResize.js
@@ -1,0 +1,54 @@
+const RESIZE_ICON_SVG = `<svg viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 6 V2 H6"/><path d="M12 8 V12 H8"/><path d="M2 2 L12 12"/></svg>`;
+
+// Pointer capture keeps the drag alive across iframes and window exits — a
+// lost mouseup would leave the drag armed. In RTL the handle sits bottom-left
+// (inset-inline-end), so the X delta flips to keep outward drags growing the
+// target.
+const startCornerResize = (handle, event, { target, containerWidth, minPx, onCommit }) => {
+  const xSign = getComputedStyle(target).direction === "rtl" ? -1 : 1;
+  const startWidth = target.getBoundingClientRect().width;
+  const startX = event.clientX;
+  const startY = event.clientY;
+  let widthPx = 0;
+
+  const onMove = (e) => {
+    const px = startWidth + xSign * (e.clientX - startX) + (e.clientY - startY);
+    widthPx = Math.max(minPx, Math.min(containerWidth, Math.round(px)));
+    target.style.width = `${widthPx}px`;
+  };
+
+  const finish = () => {
+    handle.removeEventListener("pointermove", onMove);
+    handle.removeEventListener("pointerup", finish);
+    handle.removeEventListener("pointercancel", finish);
+    if (widthPx) onCommit(widthPx);
+  };
+
+  handle.addEventListener("pointermove", onMove);
+  handle.addEventListener("pointerup", finish);
+  handle.addEventListener("pointercancel", finish);
+  // Synthetic pointer events have no active pointer to capture; the drag
+  // still tracks while the cursor stays on the handle.
+  try {
+    handle.setPointerCapture(event.pointerId);
+  } catch {
+    /* noop */
+  }
+};
+
+// Shared corner chip for images and embeds. `getOptions(event)` returns the
+// drag options, or a falsy value to ignore the press.
+export const buildResizeHandle = (label, getOptions) => {
+  const handle = document.createElement("span");
+  handle.className = "pm-resize-handle";
+  handle.contentEditable = "false";
+  handle.setAttribute("aria-label", label);
+  handle.innerHTML = RESIZE_ICON_SVG;
+  handle.addEventListener("pointerdown", (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    const options = getOptions(event);
+    if (options) startCornerResize(handle, event, options);
+  });
+  return handle;
+};

--- a/src/nodeViews/cornerResize.js
+++ b/src/nodeViews/cornerResize.js
@@ -36,10 +36,13 @@ const startCornerResize = (handle, event, { target, containerWidth, minPx, onCom
   }
 };
 
+const RESIZE_KEY_STEP = 16;
+
 // Shared corner chip for images and embeds. `getOptions(event)` returns the
-// drag options, or a falsy value to ignore the press.
+// resize options, or a falsy value to ignore the interaction.
 export const buildResizeHandle = (label, getOptions) => {
-  const handle = document.createElement("span");
+  const handle = document.createElement("button");
+  handle.type = "button";
   handle.className = "pm-resize-handle";
   handle.contentEditable = "false";
   handle.setAttribute("aria-label", label);
@@ -49,6 +52,22 @@ export const buildResizeHandle = (label, getOptions) => {
     event.stopPropagation();
     const options = getOptions(event);
     if (options) startCornerResize(handle, event, options);
+  });
+  // Keyboard resize: right/up grows, left/down shrinks.
+  handle.addEventListener("keydown", (event) => {
+    const grow = event.key === "ArrowRight" || event.key === "ArrowUp";
+    if (!grow && event.key !== "ArrowLeft" && event.key !== "ArrowDown") return;
+    const options = getOptions(event);
+    if (!options) return;
+    event.preventDefault();
+    event.stopPropagation();
+    const { target, containerWidth, minPx, onCommit } = options;
+    const width =
+      Math.round(target.getBoundingClientRect().width) +
+      (grow ? RESIZE_KEY_STEP : -RESIZE_KEY_STEP);
+    const widthPx = Math.max(minPx, Math.min(containerWidth, width));
+    target.style.width = `${widthPx}px`;
+    onCommit(widthPx);
   });
   return handle;
 };

--- a/src/nodeViews/imageResize.js
+++ b/src/nodeViews/imageResize.js
@@ -1,7 +1,9 @@
-const MIN_PX = 100;
+import { getUpload } from '../plugins/uploadState';
+import { reconcileImageUpload } from '../plugins/uploads';
+import { buildImageUploadOverlay } from './uploadOverlay';
+import { buildResizeHandle } from './cornerResize';
 
-// Diagonal-resize icon: two opposing corner brackets + connecting line.
-const HANDLE_SVG = `<svg viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 6 V2 H6"/><path d="M12 8 V12 H8"/><path d="M2 2 L12 12"/></svg>`;
+const MIN_PX = 100;
 
 class ImageResizeView {
   constructor(node, view, getPos) {
@@ -11,19 +13,38 @@ class ImageResizeView {
 
     this.dom = document.createElement('span');
     this.dom.className = 'pm-image-wrapper';
-
     this.img = document.createElement('img');
-    this.dom.appendChild(this.img);
+    this.handle = buildResizeHandle('Resize image', () => {
+      // A pasted image can sit in an inline ancestor (e.g. a link) whose
+      // clientWidth is 0; fall back to the editor width.
+      const containerWidth =
+        this.dom.parentElement?.clientWidth || this.view.dom.clientWidth;
+      if (!containerWidth) return null;
+      return {
+        target: this.dom,
+        containerWidth,
+        minPx: MIN_PX,
+        onCommit: widthPx => this.commitWidth(widthPx),
+      };
+    });
+    this.dom.append(this.img, this.handle);
 
-    this.handle = document.createElement('span');
-    this.handle.className = 'pm-image-resize-handle';
-    this.handle.contentEditable = 'false';
-    this.handle.setAttribute('aria-label', 'Resize image');
-    this.handle.innerHTML = HANDLE_SVG;
-    this.handle.addEventListener('mousedown', this.onMouseDown);
-    this.dom.appendChild(this.handle);
+    this.uploadId = null;
+    this.overlay = null;
 
     this.syncImg();
+    this.syncUpload();
+  }
+
+  commitWidth(widthPx) {
+    const pos = this.getPos();
+    if (pos == null) return;
+    this.view.dispatch(
+      this.view.state.tr.setNodeMarkup(pos, null, {
+        ...this.node.attrs,
+        width: `${widthPx}px`,
+      })
+    );
   }
 
   syncImg() {
@@ -34,58 +55,61 @@ class ImageResizeView {
     this.dom.style.width = width || '';
   }
 
-  onMouseDown = event => {
-    event.preventDefault();
-    // Pasted images can be wrapped in an inline ancestor (e.g. a link), whose
-    // clientWidth is 0; fall back to the editor width so resize still works.
-    const containerWidth =
-      this.dom.parentElement?.clientWidth || this.view.dom.clientWidth;
-    if (!containerWidth) return;
-    // In RTL the handle sits on the bottom-LEFT corner (via inset-inline-end),
-    // so outward motion is a NEGATIVE clientX delta. Flip the X contribution
-    // so dragging in the direction the icon points always grows the image.
-    const isRtl = getComputedStyle(this.dom).direction === 'rtl';
-    const xSign = isRtl ? -1 : 1;
-    const startW = this.dom.getBoundingClientRect().width;
-    const startX = event.clientX;
-    const startY = event.clientY;
-    let moved = false;
-    let widthPx = 0;
+  syncUpload() {
+    // Message-schema images have no uploadId attr — normalize to null.
+    const id = this.node.attrs.uploadId || null;
+    if (id === this.uploadId) return;
+    this.teardownUpload();
+    if (!id || !getUpload(id)) return;
+    this.uploadId = id;
+    this.overlay = buildImageUploadOverlay(id);
+    this.dom.appendChild(this.overlay);
+    this.dom.classList.add('pm-image-uploading');
+    // External mirrors have no local preview to define the box, so they get a
+    // reserved footprint; local blobs are decoded pre-insert and size exactly.
+    this.dom.classList.toggle(
+      'pm-image-uploading-external',
+      !getUpload(id).objectUrl
+    );
+  }
 
-    const onMove = e => {
-      moved = true;
-      const px = startW + xSign * (e.clientX - startX) + (e.clientY - startY);
-      widthPx = Math.max(MIN_PX, Math.min(containerWidth, Math.round(px)));
-      this.dom.style.width = `${widthPx}px`;
-    };
-
-    const onUp = () => {
-      document.removeEventListener('mousemove', onMove);
-      document.removeEventListener('mouseup', onUp);
-      if (!moved) return;
-      const pos = this.getPos();
-      if (pos == null) return;
-      this.view.dispatch(
-        this.view.state.tr.setNodeMarkup(pos, null, { ...this.node.attrs, width: `${widthPx}px` })
-      );
-    };
-
-    document.addEventListener('mousemove', onMove);
-    document.addEventListener('mouseup', onUp);
-  };
+  teardownUpload() {
+    this.uploadId = null;
+    this.dom.classList.remove('pm-image-uploading', 'pm-image-uploading-external');
+    if (!this.overlay) return;
+    const overlay = this.overlay;
+    this.overlay = null;
+    overlay.pmUploadCleanup();
+    // Fade the overlay out instead of yanking it; the src swap underneath is
+    // preloaded, so the reveal is seamless.
+    overlay.classList.add('pm-upload-done');
+    setTimeout(() => overlay.remove(), 200);
+  }
 
   update(node) {
     if (node.type !== this.node.type) return false;
     this.node = node;
     this.syncImg();
+    this.syncUpload();
     return true;
   }
 
   selectNode() { this.dom.classList.add('ProseMirror-selectednode'); }
   deselectNode() { this.dom.classList.remove('ProseMirror-selectednode'); }
   ignoreMutation() { return true; }
-  stopEvent(event) { return this.handle.contains(event.target); }
-  destroy() { this.handle.removeEventListener('mousedown', this.onMouseDown); }
+  stopEvent(event) {
+    return (
+      this.handle.contains(event.target) ||
+      Boolean(this.overlay?.contains(event.target))
+    );
+  }
+  destroy() {
+    const { uploadId, view } = this;
+    this.teardownUpload();
+    if (uploadId) {
+      queueMicrotask(() => reconcileImageUpload(view, uploadId));
+    }
+  }
 }
 
 export const imageResizeView = (node, view, getPos) =>

--- a/src/nodeViews/uploadOverlay.js
+++ b/src/nodeViews/uploadOverlay.js
@@ -1,0 +1,137 @@
+import {
+  formatBytes,
+  getUploadLabels,
+  removeUpload,
+  retryUpload,
+  subscribeUpload,
+} from "../plugins/uploadState";
+
+const VIDEO_ICON_SVG = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="5" width="18" height="14" rx="2.5"/><path d="M10 9.5 15 12l-5 2.5z" fill="currentColor" stroke="none"/></svg>`;
+const CANCEL_ICON_SVG = `<svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" aria-hidden="true"><path d="M2.5 2.5 9.5 9.5"/><path d="M9.5 2.5 2.5 9.5"/></svg>`;
+const RETRY_ICON_SVG = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/></svg>`;
+const TRASH_ICON_SVG = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 6h18"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>`;
+
+const el = (tag, className, props = {}) =>
+  Object.assign(document.createElement(tag), { className, ...props });
+
+const buildSpinner = () => {
+  const spinner = el("span", "pm-upload-spinner");
+  spinner.setAttribute("aria-hidden", "true");
+  for (let i = 0; i < 8; i += 1) {
+    spinner.appendChild(document.createElement("span"));
+  }
+  return spinner;
+};
+
+const buildButton = (className, iconSvg, onClick) => {
+  const button = el("button", className, {
+    type: "button",
+    innerHTML: iconSvg,
+  });
+  button.addEventListener("click", (event) => {
+    event.preventDefault();
+    onClick();
+  });
+  return button;
+};
+
+// Cancel while uploading; retry/remove after an error.
+const buildControls = (id) => {
+  const actions = el("span", "pm-upload-actions");
+  const retry = buildButton("pm-upload-action", RETRY_ICON_SVG, () =>
+    retryUpload(id)
+  );
+  const remove = buildButton("pm-upload-action", TRASH_ICON_SVG, () =>
+    removeUpload(id)
+  );
+  actions.append(retry, remove);
+  return {
+    cancel: buildButton("pm-upload-cancel", CANCEL_ICON_SVG, () =>
+      removeUpload(id)
+    ),
+    actions,
+    retry,
+    remove,
+  };
+};
+
+const setLabel = (button, label) => {
+  button.setAttribute("aria-label", label);
+  button.title = label;
+};
+
+// Hold at 99% while the request is open — a full bar that just sits there
+// reads worse than one pausing short.
+const displayPercent = (progress) =>
+  Math.min(99, Math.round(Math.max(0, Math.min(1, progress)) * 100));
+
+// Middle truncation keeps the extension visible on long file names.
+const displayName = (name) => {
+  const value = name || "";
+  return value.length <= 38 ? value : `${value.slice(0, 22)}…${value.slice(-12)}`;
+};
+
+const statusText = (entry, labels) => {
+  if (entry.status === "error") {
+    return entry.errorKind === "rateLimited"
+      ? labels.rateLimited
+      : labels.failed;
+  }
+  const parts = [labels.uploading];
+  if (entry.progress != null) parts.push(`${displayPercent(entry.progress)}%`);
+  const size = formatBytes(entry.size);
+  if (size) parts.push(size);
+  return parts.join(" · ");
+};
+
+const syncStatus = (dom, { cancel, retry, remove }, text, entry) => {
+  const labels = getUploadLabels();
+  dom.dataset.state = entry.status === "error" ? "error" : "uploading";
+  setLabel(retry, labels.retry);
+  setLabel(remove, labels.remove);
+  setLabel(cancel, labels.cancel);
+  text.textContent = statusText(entry, labels);
+};
+
+// Both builders return a self-subscribed element that keeps itself in sync
+// with the upload; `pmUploadCleanup` unsubscribes.
+
+// Scrim + status pill rendered over an image while it uploads.
+export const buildImageUploadOverlay = (id) => {
+  const dom = el("span", "pm-upload-overlay", { contentEditable: "false" });
+  const pill = el("span", "pm-upload-pill");
+  pill.setAttribute("role", "status");
+  const status = el("span", "pm-upload-status");
+  const text = el("span", "pm-upload-text");
+  const controls = buildControls(id);
+  status.append(buildSpinner(), text, controls.cancel);
+  pill.append(status, controls.actions);
+  dom.appendChild(pill);
+
+  dom.pmUploadCleanup = subscribeUpload(id, (entry) =>
+    syncStatus(dom, controls, text, entry)
+  );
+  return dom;
+};
+
+// Inline progress card for video uploads.
+export const buildFileUploadCard = (id) => {
+  const dom = el("span", "pm-upload-card", { contentEditable: "false" });
+  const icon = el("span", "pm-upload-card-icon", { innerHTML: VIDEO_ICON_SVG });
+  const name = el("span", "pm-upload-card-name");
+  const meta = el("span", "pm-upload-card-meta");
+  meta.setAttribute("role", "status");
+  const text = el("span", "pm-upload-text");
+  meta.append(buildSpinner(), text);
+  const body = el("span", "pm-upload-card-body");
+  body.append(name, meta);
+  const controls = buildControls(id);
+  dom.append(icon, body, controls.cancel, controls.actions);
+
+  dom.pmUploadCleanup = subscribeUpload(id, (entry) => {
+    syncStatus(dom, controls, text, entry);
+    name.textContent = displayName(entry.name);
+    name.title = entry.name || "";
+  });
+  return dom;
+};

--- a/src/plugins/embedPreview.js
+++ b/src/plugins/embedPreview.js
@@ -1,4 +1,10 @@
-import { NodeSelection, Plugin, PluginKey, TextSelection } from "prosemirror-state";
+import {
+  NodeSelection,
+  Plugin,
+  PluginKey,
+  Selection,
+  TextSelection,
+} from "prosemirror-state";
 import { Decoration, DecorationSet } from "prosemirror-view";
 
 import { getUploadLabels } from "./uploadState";
@@ -246,6 +252,84 @@ const deleteEmbedBefore = (view, embeds) => {
   return true;
 };
 
+const isHiddenSource = (node, embeds) => {
+  if (!node) return false;
+  const url = getLoneLinkUrl(node);
+  return url ? Boolean(findEmbed(embeds, url)?.hideSource) : false;
+};
+
+const hiddenSourceAt = (doc, index, embeds) =>
+  index >= 0 &&
+  index < doc.childCount &&
+  isHiddenSource(doc.child(index), embeds);
+
+const blockStart = (doc, index) => {
+  let pos = 0;
+  for (let i = 0; i < index; i += 1) pos += doc.child(i).nodeSize;
+  return pos;
+};
+
+// Arrows treat an embed like a block: they step onto it (node selection,
+// shown as a ring on the player), then past it. At the document's edge a
+// paragraph is created so there is always a line above and below a video.
+const arrowPastEmbed = (view, key, embeds) => {
+  const forward = key === "ArrowRight" || key === "ArrowDown";
+  const { selection, doc } = view.state;
+  const { $from } = selection;
+  const onEmbed =
+    selection instanceof NodeSelection &&
+    isHiddenSource(selection.node, embeds);
+
+  if (!onEmbed) {
+    if (!(selection instanceof TextSelection) || !selection.empty) return false;
+    if ($from.depth !== 1) return false;
+    const atEdge =
+      key === "ArrowUp" || key === "ArrowDown"
+        ? view.endOfTextblock(forward ? "down" : "up")
+        : $from.parentOffset === (forward ? $from.parent.content.size : 0);
+    const next = $from.index(0) + (forward ? 1 : -1);
+    // A caret inside the invisible line itself always steps out.
+    if (
+      !isHiddenSource($from.parent, embeds) &&
+      !(atEdge && hiddenSourceAt(doc, next, embeds))
+    ) {
+      return false;
+    }
+  }
+
+  const target = $from.index(0) + (forward ? 1 : -1);
+  const tr = view.state.tr;
+  if (target < 0 || target >= doc.childCount) {
+    const pos = target < 0 ? 0 : doc.content.size;
+    tr.insert(pos, view.state.schema.nodes.paragraph.create());
+    tr.setSelection(TextSelection.create(tr.doc, pos + 1));
+  } else if (hiddenSourceAt(doc, target, embeds)) {
+    tr.setSelection(NodeSelection.create(doc, blockStart(doc, target)));
+  } else {
+    const pos =
+      blockStart(doc, target) +
+      (forward ? 1 : doc.child(target).nodeSize - 1);
+    tr.setSelection(Selection.near(tr.doc.resolve(pos), forward ? 1 : -1));
+  }
+  view.dispatch(tr.scrollIntoView());
+  return true;
+};
+
+// Enter on a selected embed starts a fresh line under the player.
+const insertParagraphBelowSelectedEmbed = (view, embeds) => {
+  const { selection } = view.state;
+  if (!(selection instanceof NodeSelection)) return false;
+  if (!isHiddenSource(selection.node, embeds)) return false;
+  const after = selection.$from.pos + selection.node.nodeSize;
+  const tr = view.state.tr.insert(
+    after,
+    view.state.schema.nodes.paragraph.create()
+  );
+  tr.setSelection(TextSelection.create(tr.doc, after + 1));
+  view.dispatch(tr.scrollIntoView());
+  return true;
+};
+
 const insertParagraphAfterEmbed = (state, dispatch, embeds) => {
   if (!isTopLevelTextSelection(state.selection)) return false;
   const { schema } = state;
@@ -269,19 +353,31 @@ export const embedPreviewKey = new PluginKey("embedPreview");
 export default function embedPreviewPlugin(embeds = []) {
   return new Plugin({
     key: embedPreviewKey,
+    // A doc ending with a hidden source line leaves no visible spot below the
+    // player — keep a paragraph after it, like trailingParagraphPlugin does
+    // for atoms.
+    appendTransaction(transactions, _oldState, newState) {
+      if (!transactions.some(tr => tr.docChanged)) return null;
+      const { doc, schema } = newState;
+      if (!isHiddenSource(doc.lastChild, embeds)) return null;
+      return newState.tr.insert(
+        doc.content.size,
+        schema.nodes.paragraph.create()
+      );
+    },
     state: {
       init(_, { doc }) {
         const items = collectEmbeds(doc, embeds);
-        return { set: buildSet(doc, items), signature: signatureOf(items) };
+        return { set: buildSet(doc, items), signature: signatureOf(items), items };
       },
       apply(tr, old) {
         if (!tr.docChanged) return old;
         const items = collectEmbeds(tr.doc, embeds);
         const signature = signatureOf(items);
         if (signature === old.signature) {
-          return { set: old.set.map(tr.mapping, tr.doc), signature };
+          return { set: old.set.map(tr.mapping, tr.doc), signature, items };
         }
-        return { set: buildSet(tr.doc, items), signature };
+        return { set: buildSet(tr.doc, items), signature, items };
       },
     },
     // Back online, reload any player that died while the connection was down.
@@ -301,6 +397,22 @@ export default function embedPreviewPlugin(embeds = []) {
       };
       window.addEventListener("online", reloadFailedMedia);
       return {
+        // Widget identity ignores sizing params so a resize never remounts a
+        // playing video — the trade-off is that undo/redo of a resize keeps
+        // the old wrapper. Sync its width to the document instead.
+        update(view) {
+          const { items } = embedPreviewKey.getState(view.state);
+          if (!items.length) return;
+          view.dom
+            .querySelectorAll(".cw-embed-preview")
+            .forEach((el, index) => {
+              const item = items[index];
+              if (!item) return;
+              const width = embedWidth(item.url);
+              const target = width ? `${width}px` : "";
+              if (el.style.width !== target) el.style.width = target;
+            });
+        },
         destroy: () => window.removeEventListener("online", reloadFailedMedia),
       };
     },
@@ -312,7 +424,10 @@ export default function embedPreviewPlugin(embeds = []) {
         if (event.shiftKey || event.metaKey || event.ctrlKey || event.altKey)
           return false;
         if (event.key === "Backspace") return deleteEmbedBefore(view, embeds);
+        if (event.key.startsWith("Arrow"))
+          return arrowPastEmbed(view, event.key, embeds);
         if (event.key !== "Enter") return false;
+        if (insertParagraphBelowSelectedEmbed(view, embeds)) return true;
         return insertParagraphAfterEmbed(
           view.state,
           tr => view.dispatch(tr),

--- a/src/plugins/embedPreview.js
+++ b/src/plugins/embedPreview.js
@@ -1,5 +1,8 @@
-import { Plugin, PluginKey, TextSelection } from "prosemirror-state";
+import { NodeSelection, Plugin, PluginKey, TextSelection } from "prosemirror-state";
 import { Decoration, DecorationSet } from "prosemirror-view";
+
+import { getUploadLabels } from "./uploadState";
+import { buildResizeHandle } from "../nodeViews/cornerResize";
 
 const isTopLevelTextSelection = selection =>
   selection instanceof TextSelection &&
@@ -23,9 +26,8 @@ const getLoneLinkUrl = paragraph => {
   return url;
 };
 
-// Captures come straight from the URL and land inside attribute values, so
-// escape them before interpolation — otherwise a crafted id can break out and
-// inject attributes (e.g. a quote in a YouTube video id adding an onload).
+// Captures come straight from the URL and land inside attribute values —
+// escape them, or a crafted id could break out and inject attributes.
 const escapeHtml = value =>
   String(value)
     .replaceAll("&", "&amp;")
@@ -40,19 +42,144 @@ const renderTemplate = (template, captures) =>
     template
   );
 
-export const findEmbedHtml = (embeds, url) => {
-  for (const { regex, template } of embeds) {
-    const match = url.match(regex);
-    if (match) return renderTemplate(template, match.groups || {});
+const findEmbed = (embeds, url) => {
+  for (const embed of embeds) {
+    const match = url.match(embed.regex);
+    if (match) {
+      return {
+        html: renderTemplate(embed.template, match.groups || {}),
+        hideSource: Boolean(embed.hideSource),
+      };
+    }
   }
   return null;
 };
 
-const buildEmbedWidget = html => () => {
+export const findEmbedHtml = (embeds, url) => findEmbed(embeds, url)?.html ?? null;
+
+const REMOVE_ICON_SVG = `<svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" aria-hidden="true"><path d="M2.5 2.5 9.5 9.5"/><path d="M9.5 2.5 2.5 9.5"/></svg>`;
+
+const MIN_EMBED_PX = 220;
+
+const stripParams = (url, names) => {
+  const at = url.indexOf("?");
+  if (at === -1) return url;
+  const kept = url
+    .slice(at + 1)
+    .split("&")
+    .filter(part => part && !names.includes(part.split("=")[0]));
+  return kept.length ? `${url.slice(0, at)}?${kept.join("&")}` : url.slice(0, at);
+};
+
+// Sizing params are presentation only; widget identity ignores them so a
+// resize never remounts a playing video.
+const stripEmbedParams = url => stripParams(url, ["cw_video_width", "cw_video_ar"]);
+
+const withWidthParam = (url, px) => {
+  const base = stripParams(url, ["cw_video_width"]);
+  return `${base}${base.includes("?") ? "&" : "?"}cw_video_width=${px}px`;
+};
+
+const embedWidth = url => {
+  const match = url.match(/[?&]cw_video_width=(\d+)px(?:&|$)/);
+  return match ? Number(match[1]) : null;
+};
+
+const embedRatio = url => {
+  const match = url.match(/[?&]cw_video_ar=(\d{1,5})x(\d{1,5})(?:&|$)/);
+  return match ? `${match[1]} / ${match[2]}` : null;
+};
+
+// Persist a resize by rewriting the hidden source link's href; the width param
+// round-trips through markdown and the portal renderer sizes the embed from it.
+const setSourceWidth = (view, pos, px) => {
+  const source = view.state.doc.resolve(pos).nodeBefore;
+  if (!source) return;
+  const linkType = view.state.schema.marks.link;
+  const start = pos - source.nodeSize + 1;
+  const tr = view.state.tr;
+  source.forEach((child, offset) => {
+    const mark = child.marks.find(item => item.type === linkType);
+    if (!mark) return;
+    const from = start + offset;
+    const to = from + child.nodeSize;
+    tr.removeMark(from, to, linkType);
+    tr.addMark(
+      from,
+      to,
+      linkType.create({ ...mark.attrs, href: withWidthParam(mark.attrs.href, px) })
+    );
+  });
+  if (tr.steps.length) view.dispatch(tr);
+};
+
+const deleteSourceBefore = (view, pos) => {
+  const source = view.state.doc.resolve(pos).nodeBefore;
+  if (!source) return;
+  view.dispatch(view.state.tr.delete(pos - source.nodeSize, pos));
+  view.focus();
+};
+
+// The hidden source line can't be clicked, so removable previews carry their
+// own remove and resize controls; background clicks select the hidden source.
+const decorateRemovablePreview = (wrapper, view, getPos) => {
+  wrapper.classList.add("cw-embed-preview--removable");
+
+  const remove = document.createElement("button");
+  remove.type = "button";
+  remove.className = "cw-embed-remove";
+  remove.setAttribute("aria-label", getUploadLabels().remove);
+  remove.innerHTML = REMOVE_ICON_SVG;
+  remove.addEventListener("mousedown", event => {
+    event.preventDefault();
+    event.stopPropagation();
+  });
+  remove.addEventListener("click", event => {
+    event.preventDefault();
+    event.stopPropagation();
+    deleteSourceBefore(view, getPos());
+  });
+
+  const resize = buildResizeHandle("Resize video", () => {
+    const containerWidth =
+      wrapper.parentElement?.clientWidth || view.dom.clientWidth;
+    if (!containerWidth) return null;
+    return {
+      target: wrapper,
+      containerWidth,
+      minPx: MIN_EMBED_PX,
+      onCommit: widthPx => setSourceWidth(view, getPos(), widthPx),
+    };
+  });
+
+  wrapper.append(remove, resize);
+  wrapper.addEventListener("mousedown", event => {
+    if (event.target.closest("video, iframe, a, button")) return;
+    const pos = getPos();
+    const $pos = view.state.doc.resolve(pos);
+    if (!$pos.nodeBefore) return;
+    event.preventDefault();
+    view.dispatch(
+      view.state.tr.setSelection(
+        NodeSelection.create(view.state.doc, pos - $pos.nodeBefore.nodeSize)
+      )
+    );
+    view.focus();
+  });
+};
+
+const buildEmbedWidget = (html, { selectSource = false, url = "" } = {}) => (view, getPos) => {
   const wrapper = document.createElement("div");
   wrapper.className = "cw-embed-preview";
   wrapper.contentEditable = "false";
   wrapper.innerHTML = html;
+  const savedWidth = url && embedWidth(url);
+  if (savedWidth) wrapper.style.width = `${savedWidth}px`;
+  const savedRatio = url && embedRatio(url);
+  if (savedRatio) {
+    const media = wrapper.querySelector("video");
+    if (media) media.style.aspectRatio = savedRatio;
+  }
   // innerHTML doesn't execute <script> tags — re-create them so they do.
   wrapper.querySelectorAll("script").forEach(stale => {
     const fresh = document.createElement("script");
@@ -62,6 +189,7 @@ const buildEmbedWidget = html => () => {
     fresh.textContent = stale.textContent;
     stale.replaceWith(fresh);
   });
+  if (selectSource) decorateRemovablePreview(wrapper, view, getPos);
   return wrapper;
 };
 
@@ -70,9 +198,17 @@ const collectEmbeds = (doc, embeds) => {
   doc.forEach((node, offset, index) => {
     const url = getLoneLinkUrl(node);
     if (!url) return;
-    const html = findEmbedHtml(embeds, url);
-    if (!html) return;
-    items.push({ index, offset, nodeSize: node.nodeSize, url, html });
+    const embed = findEmbed(embeds, url);
+    if (!embed) return;
+    items.push({
+      index,
+      offset,
+      nodeSize: node.nodeSize,
+      url,
+      key: stripEmbedParams(url),
+      html: embed.html,
+      hideSource: embed.hideSource,
+    });
   });
   return items;
 };
@@ -80,17 +216,45 @@ const collectEmbeds = (doc, embeds) => {
 const buildSet = (doc, items) =>
   DecorationSet.create(
     doc,
-    items.map(item =>
-      Decoration.widget(
+    items.flatMap(item => {
+      const widget = Decoration.widget(
         item.offset + item.nodeSize,
-        buildEmbedWidget(item.html),
-        { side: -1, key: `embed:${item.url}` }
-      )
-    )
+        buildEmbedWidget(item.html, { selectSource: item.hideSource, url: item.url }),
+        { side: -1, key: `embed:${item.key}` }
+      );
+      if (!item.hideSource) return [widget];
+      // The preview fully represents the content, so the raw source line
+      // stays out of sight — matching the portal, which renders only the embed.
+      return [
+        widget,
+        Decoration.node(item.offset, item.offset + item.nodeSize, {
+          class: "cw-embed-source-hidden",
+        }),
+      ];
+    })
   );
 
 const signatureOf = items =>
-  items.map(item => `${item.index}:${item.url}`).join("|");
+  items.map(item => `${item.index}:${item.key}`).join("|");
+
+// Backspace after a hidden-source embed removes the whole embed — otherwise
+// it silently eats the invisible link text character by character.
+const deleteEmbedBefore = (view, embeds) => {
+  const { state } = view;
+  const { selection } = state;
+  if (!(selection instanceof TextSelection) || !selection.empty) return false;
+  const { $from } = selection;
+  if ($from.depth !== 1 || $from.parentOffset !== 0) return false;
+  const index = $from.index(0);
+  if (index === 0) return false;
+  const before = state.doc.child(index - 1);
+  const url = getLoneLinkUrl(before);
+  if (!url) return false;
+  if (!findEmbed(embeds, url)?.hideSource) return false;
+  const end = $from.before();
+  view.dispatch(state.tr.delete(end - before.nodeSize, end));
+  return true;
+};
 
 const insertParagraphAfterEmbed = (state, dispatch, embeds) => {
   if (!isTopLevelTextSelection(state.selection)) return false;
@@ -130,14 +294,35 @@ export default function embedPreviewPlugin(embeds = []) {
         return { set: buildSet(tr.doc, items), signature };
       },
     },
+    // Back online, reload any player that died while the connection was down.
+    // A failed <source> never sets `error` — it parks in NETWORK_NO_SOURCE.
+    view(editorView) {
+      const reloadFailedMedia = () => {
+        editorView.dom
+          .querySelectorAll(".cw-embed-preview video")
+          .forEach(media => {
+            if (
+              media.error ||
+              media.networkState === HTMLMediaElement.NETWORK_NO_SOURCE
+            ) {
+              media.load();
+            }
+          });
+      };
+      window.addEventListener("online", reloadFailedMedia);
+      return {
+        destroy: () => window.removeEventListener("online", reloadFailedMedia),
+      };
+    },
     props: {
       decorations(state) {
         return embedPreviewKey.getState(state).set;
       },
       handleKeyDown(view, event) {
-        if (event.key !== "Enter") return false;
         if (event.shiftKey || event.metaKey || event.ctrlKey || event.altKey)
           return false;
+        if (event.key === "Backspace") return deleteEmbedBefore(view, embeds);
+        if (event.key !== "Enter") return false;
         return insertParagraphAfterEmbed(
           view.state,
           tr => view.dispatch(tr),

--- a/src/plugins/embedPreview.js
+++ b/src/plugins/embedPreview.js
@@ -71,9 +71,9 @@ const stripParams = (url, names) => {
   return kept.length ? `${url.slice(0, at)}?${kept.join("&")}` : url.slice(0, at);
 };
 
-// Sizing params are presentation only; widget identity ignores them so a
+// The width param is presentation only; widget identity ignores it so a
 // resize never remounts a playing video.
-const stripEmbedParams = url => stripParams(url, ["cw_video_width", "cw_video_ar"]);
+const stripEmbedParams = url => stripParams(url, ["cw_video_width"]);
 
 const withWidthParam = (url, px) => {
   const base = stripParams(url, ["cw_video_width"]);
@@ -83,11 +83,6 @@ const withWidthParam = (url, px) => {
 const embedWidth = url => {
   const match = url.match(/[?&]cw_video_width=(\d+)px(?:&|$)/);
   return match ? Number(match[1]) : null;
-};
-
-const embedRatio = url => {
-  const match = url.match(/[?&]cw_video_ar=(\d{1,5})x(\d{1,5})(?:&|$)/);
-  return match ? `${match[1]} / ${match[2]}` : null;
 };
 
 // Persist a resize by rewriting the hidden source link's href; the width param
@@ -175,11 +170,6 @@ const buildEmbedWidget = (html, { selectSource = false, url = "" } = {}) => (vie
   wrapper.innerHTML = html;
   const savedWidth = url && embedWidth(url);
   if (savedWidth) wrapper.style.width = `${savedWidth}px`;
-  const savedRatio = url && embedRatio(url);
-  if (savedRatio) {
-    const media = wrapper.querySelector("video");
-    if (media) media.style.aspectRatio = savedRatio;
-  }
   // innerHTML doesn't execute <script> tags — re-create them so they do.
   wrapper.querySelectorAll("script").forEach(stale => {
     const fresh = document.createElement("script");

--- a/src/plugins/image.js
+++ b/src/plugins/image.js
@@ -1,10 +1,7 @@
 import { Plugin } from "prosemirror-state";
 
-/**
- * Check if URL is valid HTTP/HTTPS.
- * @param {string} url - URL to validate
- * @returns {boolean} True if valid HTTP/HTTPS URL
- */
+import { deleteImagesBySrc, mirrorExternalImages } from "./uploads";
+
 function isValidImageUrl(url) {
   if (!url) return false;
   try {
@@ -15,70 +12,44 @@ function isValidImageUrl(url) {
   }
 }
 
-/**
- * Update or remove an image in the editor.
- * @param {string} oldUrl - Current image URL
- * @param {string|null} newUrl - New URL to replace with, or null to remove
- * @param {EditorView} view - ProseMirror editor view
- */
-function modifyImage(oldUrl, newUrl, view) {
-  const tr = view.state.tr;
-
-  view.state.doc.descendants((node, pos) => {
-    if (node.type.name === "image" && node.attrs.src === oldUrl) {
-      newUrl
-        ? tr.setNodeMarkup(pos, null, { ...node.attrs, src: newUrl })
-        : tr.delete(pos, pos + node.nodeSize);
-    }
-  });
-
-  if (tr.docChanged) view.dispatch(tr);
+// Own-origin images (earlier uploads copied between articles) need no
+// mirroring — and the server rejects its own URLs anyway.
+function isSameOrigin(url) {
+  try {
+    return new URL(url, window.location.href).origin === window.location.origin;
+  } catch {
+    return false;
+  }
 }
 
-/**
- * Creates a ProseMirror plugin that handles image pasting and uploading.
- *
- * @param {Function} uploadImage - A function that takes an image URL and returns a Promise
- * that resolves to the new URL after uploading.
- * @returns {Plugin} A ProseMirror plugin that handles image pasting.
- */
+// Mirrors pasted external images into storage: images stay visible with an
+// upload overlay while mirroring, duplicate URLs upload once, and a failed
+// mirror keeps the image with retry/remove controls instead of deleting it.
+// `uploadImage` is (url, signal) => Promise<newUrl>.
 const imagePastePlugin = (uploadImage) =>
   new Plugin({
     props: {
-      /**
-       * Handles the paste event in the editor.
-       *
-       * @param {EditorView} view - The ProseMirror editor view.
-       * @param {Event} event - The paste event.
-       * @param {Slice} slice - The ProseMirror Slice object representing the pasted content.
-       */
       handlePaste(view, event, slice) {
-        const valid = [];
+        const external = [];
         const invalid = [];
 
-        // Collect image URLs
         slice.content.descendants((node) => {
-          if (node.type.name === "image") {
-            const url = node.attrs.src;
-            const isValid = isValidImageUrl(url);
-            isValid ? valid.push(url) : invalid.push(url);
-          }
+          if (node.type.name !== "image") return;
+          const url = node.attrs.src;
+          // blob: previews are this editor's own in-flight uploads being
+          // copied around — leave them to their original upload.
+          if (typeof url === "string" && url.startsWith("blob:")) return;
+          if (isSameOrigin(url)) return;
+          if (isValidImageUrl(url)) external.push(url);
+          else invalid.push(url);
         });
 
-        // Process after paste completes
+        // Run after the paste has landed in the doc.
         setTimeout(() => {
-          // Remove invalid images
-          invalid.forEach((url) => modifyImage(url, null, view));
-
-          // Upload valid images
-          valid.forEach(async (url) => {
-            try {
-              const newUrl = await uploadImage(url);
-              modifyImage(url, newUrl, view);
-            } catch (error) {
-              console.error("Error uploading image:", error);
-            }
-          });
+          invalid.forEach((url) => deleteImagesBySrc(view, url));
+          if (external.length) {
+            mirrorExternalImages(view, external, { upload: uploadImage });
+          }
         }, 0);
       },
     },

--- a/src/plugins/uploadState.js
+++ b/src/plugins/uploadState.js
@@ -1,0 +1,157 @@
+const DEFAULT_LABELS = {
+  uploading: "Uploading…",
+  failed: "Upload failed",
+  rateLimited: "Upload limit reached. Try again in a few minutes.",
+  retry: "Retry",
+  remove: "Remove",
+  cancel: "Cancel upload",
+};
+
+const labels = { ...DEFAULT_LABELS };
+
+export const setUploadLabels = (next = {}) => {
+  Object.keys(DEFAULT_LABELS).forEach((key) => {
+    if (next[key]) labels[key] = next[key];
+  });
+};
+
+export const getUploadLabels = () => labels;
+
+const uploads = new Map();
+let uploadCounter = 0;
+
+export const newUploadId = () => {
+  uploadCounter += 1;
+  return `pm-upload-${uploadCounter}`;
+};
+
+export const getUpload = (id) => uploads.get(id) || null;
+
+// run/remove/abort closures let any surface drive an upload without knowing
+// which pipeline owns it.
+export const registerUpload = (id, data) => {
+  uploads.set(id, {
+    status: "uploading",
+    progress: null,
+    errorKind: null,
+    listeners: new Set(),
+    ...data,
+  });
+  return uploads.get(id);
+};
+
+export const patchUpload = (id, patch) => {
+  const entry = uploads.get(id);
+  if (!entry) return;
+  Object.assign(entry, patch);
+  entry.listeners.forEach((listener) => listener(entry));
+};
+
+export const subscribeUpload = (id, listener) => {
+  const entry = uploads.get(id);
+  if (!entry) return () => {};
+  entry.listeners.add(listener);
+  listener(entry);
+  return () => entry.listeners.delete(listener);
+};
+
+// Object URLs are never revoked: undo/redo can resurface a node that still
+// points at its blob preview.
+export const releaseUpload = (id) => {
+  uploads.delete(id);
+};
+
+export const retryUpload = (id) => {
+  const entry = uploads.get(id);
+  if (entry?.status === "error") entry.run();
+};
+
+export const removeUpload = (id) => {
+  const entry = uploads.get(id);
+  if (!entry) return;
+  entry.abort?.();
+  entry.remove?.();
+  releaseUpload(id);
+};
+
+// For uploads whose placeholder is already gone: abort and forget.
+export const abandonUpload = (id) => {
+  const entry = uploads.get(id);
+  if (!entry) return;
+  entry.abort?.();
+  releaseUpload(id);
+};
+
+// Bounded concurrency so a large paste doesn't fire dozens of parallel
+// requests. Tasks must never reject.
+const MAX_CONCURRENT_UPLOADS = 3;
+let activeUploads = 0;
+const uploadQueue = [];
+
+const drainQueue = () => {
+  while (activeUploads < MAX_CONCURRENT_UPLOADS && uploadQueue.length) {
+    const task = uploadQueue.shift();
+    activeUploads += 1;
+    task().finally(() => {
+      activeUploads -= 1;
+      drainQueue();
+    });
+  }
+};
+
+// One attempt: queue the request, then land in complete(url) or the error
+// state. An abort never surfaces as an error.
+export const runUpload = (id, { progress = null, request, complete }) => {
+  const controller = new AbortController();
+  patchUpload(id, {
+    status: "uploading",
+    progress,
+    errorKind: null,
+    abort: () => controller.abort(),
+  });
+  uploadQueue.push(async () => {
+    if (controller.signal.aborted) return;
+    try {
+      const url = await request(controller.signal);
+      if (!url) throw new Error("Upload failed");
+      await complete(url);
+    } catch (error) {
+      if (controller.signal.aborted) return;
+      const errorKind =
+        error?.response?.status === 429 ? "rateLimited" : "failed";
+      patchUpload(id, { status: "error", errorKind });
+    }
+  });
+  drainQueue();
+};
+
+export const formatBytes = (bytes) => {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "";
+  const units = ["B", "KB", "MB", "GB"];
+  const index = Math.min(
+    units.length - 1,
+    Math.floor(Math.log(bytes) / Math.log(1024))
+  );
+  const value = bytes / 1024 ** index;
+  const rounded =
+    value >= 10 || index === 0 ? Math.round(value) : value.toFixed(1);
+  return `${rounded} ${units[index]}`;
+};
+
+// Warm the cache before a node swaps to its uploaded URL so the swap never
+// flashes. Resolves on failure or timeout too — the swap must happen anyway.
+export const preloadImage = (url, timeoutMs = 8000) =>
+  new Promise((resolve) => {
+    const img = new Image();
+    if (typeof img.decode !== "function") {
+      resolve();
+      return;
+    }
+    const timer = setTimeout(resolve, timeoutMs);
+    const done = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    img.src = url;
+    img.decode().then(done, done);
+  });

--- a/src/plugins/uploads.js
+++ b/src/plugins/uploads.js
@@ -85,6 +85,23 @@ const deleteUploadImages = (view, id) => {
   deleteImages(view, findUploadImages(view.state.doc, id, entry.objectUrl));
 };
 
+// Mirroring enhances an already-valid image, and its tag can cover
+// pre-existing duplicates of the pasted URL — so cancelling only clears the
+// transient tag and keeps every image.
+const clearImageUploadTags = (view, id) => {
+  if (view.isDestroyed) return;
+  const matches = findImages(
+    view.state.doc,
+    (node) => node.attrs.uploadId === id
+  );
+  if (!matches.length) return;
+  const tr = view.state.tr;
+  matches.forEach(({ node, pos }) => {
+    tr.setNodeMarkup(pos, null, { ...node.attrs, uploadId: null });
+  });
+  view.dispatch(tr.setMeta("addToHistory", false));
+};
+
 const swapUploadedImages = (view, id, url) =>
   finishUpload(view, id, (entry) => {
     const matches = findUploadImages(view.state.doc, id, entry.objectUrl);
@@ -93,7 +110,9 @@ const swapUploadedImages = (view, id, url) =>
     matches.forEach(({ node, pos }) => {
       tr.setNodeMarkup(pos, null, { ...node.attrs, src: url, uploadId: null });
     });
-    view.dispatch(tr);
+    // Async completion, not a user edit: keep it out of history so undo
+    // can't resurrect the unserializable blob preview.
+    view.dispatch(tr.setMeta("addToHistory", false));
   });
 
 const runImageUpload = (view, id, request, progress = null) =>
@@ -193,10 +212,10 @@ export const mirrorExternalImages = (view, urls, { upload }) => {
     registerUpload(id, {
       kind: "image",
       run: () => runImageUpload(view, id, (signal) => upload(src, signal)),
-      remove: () => deleteUploadImages(view, id),
+      remove: () => clearImageUploadTags(view, id),
     });
   });
-  view.dispatch(tr);
+  view.dispatch(tr.setMeta("addToHistory", false));
   assignments.forEach((id) => getUpload(id).run());
 };
 
@@ -327,10 +346,29 @@ const reconcileFileUpload = (view, id) => {
 // Upload video files with an inline progress card at the caret; on success
 // the card becomes a lone paragraph linking the file name to the uploaded URL
 // (the mp4 embed matches the href, so a player renders in its place).
+// Completions flush in selection order: a finished file waits while an
+// earlier pick is still uploading, so multi-file uploads keep their order.
 // `upload` is (file, onProgress, signal) => Promise<url>.
 export const insertFileUploads = (view, files, { upload }) => {
-  Array.from(files).forEach((file) => {
-    const id = newUploadId();
+  const batch = Array.from(files).map((file) => ({
+    file,
+    id: newUploadId(),
+    url: null,
+    inserted: false,
+  }));
+  const flush = () => {
+    for (const item of batch) {
+      if (item.inserted) continue;
+      if (item.url) {
+        item.inserted = true;
+        completeFileUpload(view, item.id, item.url);
+      } else if (getUpload(item.id)?.status === "uploading") {
+        return;
+      }
+      // Failed or removed entries don't block the files behind them.
+    }
+  };
+  batch.forEach(({ id, file }) => {
     registerUpload(id, {
       kind: "file",
       name: file.name,
@@ -339,7 +377,10 @@ export const insertFileUploads = (view, files, { upload }) => {
         runUpload(id, {
           progress: 0,
           request: fileRequest(id, file, upload),
-          complete: (url) => completeFileUpload(view, id, url),
+          complete: (url) => {
+            batch.find((item) => item.id === id).url = url;
+            flush();
+          },
         }),
       remove: () => removeUploadWidget(view, id),
     });
@@ -352,7 +393,10 @@ export const insertFileUploads = (view, files, { upload }) => {
         side: -1,
         destroy: (dom) => {
           dom.pmUploadCleanup?.();
-          queueMicrotask(() => reconcileFileUpload(view, id));
+          queueMicrotask(() => {
+            reconcileFileUpload(view, id);
+            flush();
+          });
         },
       }
     );

--- a/src/plugins/uploads.js
+++ b/src/plugins/uploads.js
@@ -302,20 +302,14 @@ const removeUploadWidget = (view, id) => {
   view.dispatch(view.state.tr.setMeta(fileUploadKey, { removeId: id }));
 };
 
-// The link lands where the card was shown (which can be mid-textblock) and
-// carries the probed video dimensions so the embed reserves its exact box.
+// The link lands where the card was shown (which can be mid-textblock).
 const completeFileUpload = (view, id, url) =>
   finishUpload(view, id, (entry) => {
     const { state } = view;
     const widget = findUploadWidget(view, id);
     let tr = state.tr;
     if (widget) {
-      let href = url;
-      if (entry.dimensions) {
-        const { width, height } = entry.dimensions;
-        href += `${href.includes("?") ? "&" : "?"}cw_video_ar=${width}x${height}`;
-      }
-      const mark = state.schema.marks.link.create({ href });
+      const mark = state.schema.marks.link.create({ href: url });
       const paragraph = state.schema.nodes.paragraph.create(
         null,
         state.schema.text(entry.name || url, [mark])
@@ -329,30 +323,6 @@ const reconcileFileUpload = (view, id) => {
   if (!getUpload(id)) return;
   if (view.isDestroyed || !findUploadWidget(view, id)) abandonUpload(id);
 };
-
-// Read the video's dimensions from the local file so the embed can reserve
-// its exact box from the first paint. Resolves null on failure or timeout.
-const probeVideoSize = (file) =>
-  new Promise((resolve) => {
-    const url = URL.createObjectURL(file);
-    const probe = document.createElement("video");
-    const done = (size) => {
-      clearTimeout(timer);
-      probe.removeAttribute("src");
-      URL.revokeObjectURL(url);
-      resolve(size);
-    };
-    const timer = setTimeout(() => done(null), 2000);
-    probe.preload = "metadata";
-    probe.onloadedmetadata = () =>
-      done(
-        probe.videoWidth && probe.videoHeight
-          ? { width: probe.videoWidth, height: probe.videoHeight }
-          : null
-      );
-    probe.onerror = () => done(null);
-    probe.src = url;
-  });
 
 // Upload video files with an inline progress card at the caret; on success
 // the card becomes a lone paragraph linking the file name to the uploaded URL
@@ -372,9 +342,6 @@ export const insertFileUploads = (view, files, { upload }) => {
           complete: (url) => completeFileUpload(view, id, url),
         }),
       remove: () => removeUploadWidget(view, id),
-    });
-    probeVideoSize(file).then((dimensions) => {
-      if (dimensions) patchUpload(id, { dimensions });
     });
     const widget = Decoration.widget(
       view.state.selection.from,

--- a/src/plugins/uploads.js
+++ b/src/plugins/uploads.js
@@ -12,6 +12,7 @@ import {
   releaseUpload,
   removeUpload,
   runUpload,
+  subscribeUpload,
 } from "./uploadState";
 
 // Insert a block node as close to $pos as the structure allows: before/after
@@ -383,6 +384,10 @@ export const insertFileUploads = (view, files, { upload }) => {
           },
         }),
       remove: () => removeUploadWidget(view, id),
+    });
+    // A failure unblocks the finished files queued behind it.
+    subscribeUpload(id, ({ status }) => {
+      if (status === "error") flush();
     });
     const widget = Decoration.widget(
       view.state.selection.from,

--- a/src/plugins/uploads.js
+++ b/src/plugins/uploads.js
@@ -64,13 +64,15 @@ const findUploadImages = (doc, id, objectUrl) =>
   );
 
 // Delete bottom-up so earlier deletes don't shift later positions.
+// Previews aren't real content: their deletion must not create a history
+// step, or undo would revive an image whose upload no longer exists.
 const deleteImages = (view, matches) => {
   if (!matches.length) return;
   const tr = view.state.tr;
   matches
     .sort((a, b) => b.pos - a.pos)
     .forEach(({ node, pos }) => tr.delete(pos, pos + node.nodeSize));
-  view.dispatch(tr);
+  view.dispatch(tr.setMeta("addToHistory", false));
 };
 
 export const deleteImagesBySrc = (view, src) =>
@@ -171,15 +173,14 @@ export const insertImageFiles = (view, files, { upload }) => {
     for (const { id, objectUrl } of queue) {
       await preloadImage(objectUrl, 3000);
       if (!getUpload(id)) continue;
-      if (view.isDestroyed) {
+      // A missing anchor means the document was rebuilt (e.g. an external
+      // reset) while the preview decoded — the files no longer belong there.
+      const pos = view.isDestroyed ? null : insertAnchorPos(view, anchor);
+      if (pos === null) {
         releaseUpload(id);
         continue;
       }
-      insertImageNode(
-        view,
-        { src: objectUrl, uploadId: id },
-        insertAnchorPos(view, anchor)
-      );
+      insertImageNode(view, { src: objectUrl, uploadId: id }, pos);
       getUpload(id).run();
     }
     dropInsertAnchor(view, anchor);
@@ -283,8 +284,7 @@ const addInsertAnchor = (view) => {
 };
 
 const insertAnchorPos = (view, id) =>
-  fileUploadKey.getState(view.state)?.anchors.get(id) ??
-  view.state.selection.from;
+  fileUploadKey.getState(view.state)?.anchors.get(id) ?? null;
 
 const dropInsertAnchor = (view, id) => {
   if (view.isDestroyed) return;

--- a/src/plugins/uploads.js
+++ b/src/plugins/uploads.js
@@ -1,0 +1,395 @@
+import { Plugin, PluginKey } from "prosemirror-state";
+import { Decoration, DecorationSet } from "prosemirror-view";
+
+import { buildFileUploadCard } from "../nodeViews/uploadOverlay";
+import {
+  abandonUpload,
+  getUpload,
+  newUploadId,
+  patchUpload,
+  preloadImage,
+  registerUpload,
+  releaseUpload,
+  removeUpload,
+  runUpload,
+} from "./uploadState";
+
+// Insert a block node as close to $pos as the structure allows: before/after
+// the textblock at its edges, or by splitting it mid-text (consuming an
+// adjacent soft line break so no blank line is left). Never replaces the
+// block at $pos — decorations anchored there must survive.
+const insertBlockNear = (tr, $pos, node) => {
+  if (!$pos.parent.isTextblock) return tr.insert($pos.pos, node);
+  if ($pos.parentOffset === 0) return tr.insert($pos.before(), node);
+  if ($pos.parentOffset === $pos.parent.content.size) {
+    return tr.insert($pos.after(), node);
+  }
+  let pos = $pos.pos;
+  if ($pos.nodeBefore?.type.name === "hard_break") {
+    tr = tr.delete(pos - 1, pos);
+    pos -= 1;
+  } else if ($pos.nodeAfter?.type.name === "hard_break") {
+    tr = tr.delete(pos, pos + 1);
+  }
+  return tr.split(pos).insert(pos + 1, node);
+};
+
+const fileRequest = (id, file, upload) => (signal) =>
+  upload(file, (progress) => patchUpload(id, { progress }), signal);
+
+// Apply only while the upload and the view are alive, then drop the entry.
+const finishUpload = (view, id, apply) => {
+  const entry = getUpload(id);
+  if (entry && !view.isDestroyed) apply(entry);
+  releaseUpload(id);
+};
+
+// --- Images: upload behind the visible node (blob preview or pasted external
+// URL) and swap src in place; the uploadId attr ties node and upload.
+
+const findImages = (doc, test) => {
+  const matches = [];
+  doc.descendants((node, pos) => {
+    if (node.type.name === "image" && test(node)) matches.push({ node, pos });
+  });
+  return matches;
+};
+
+// Fall back to the preview URL for copies that lost the uploadId attr.
+const findUploadImages = (doc, id, objectUrl) =>
+  findImages(
+    doc,
+    (node) =>
+      node.attrs.uploadId === id || (objectUrl && node.attrs.src === objectUrl)
+  );
+
+// Delete bottom-up so earlier deletes don't shift later positions.
+const deleteImages = (view, matches) => {
+  if (!matches.length) return;
+  const tr = view.state.tr;
+  matches
+    .sort((a, b) => b.pos - a.pos)
+    .forEach(({ node, pos }) => tr.delete(pos, pos + node.nodeSize));
+  view.dispatch(tr);
+};
+
+export const deleteImagesBySrc = (view, src) =>
+  deleteImages(
+    view,
+    findImages(view.state.doc, (node) => node.attrs.src === src)
+  );
+
+const deleteUploadImages = (view, id) => {
+  const entry = getUpload(id);
+  if (!entry || view.isDestroyed) return;
+  deleteImages(view, findUploadImages(view.state.doc, id, entry.objectUrl));
+};
+
+const swapUploadedImages = (view, id, url) =>
+  finishUpload(view, id, (entry) => {
+    const matches = findUploadImages(view.state.doc, id, entry.objectUrl);
+    if (!matches.length) return;
+    const tr = view.state.tr;
+    matches.forEach(({ node, pos }) => {
+      tr.setNodeMarkup(pos, null, { ...node.attrs, src: url, uploadId: null });
+    });
+    view.dispatch(tr);
+  });
+
+const runImageUpload = (view, id, request, progress = null) =>
+  runUpload(id, {
+    progress,
+    request,
+    complete: async (url) => {
+      await preloadImage(url);
+      swapUploadedImages(view, id, url);
+    },
+  });
+
+const insertImageNode = (view, attrs, pos) => {
+  const { state } = view;
+  const image = state.schema.nodes.image.create(attrs);
+  const paragraph = state.schema.nodes.paragraph.create(null, image);
+  const tr = insertBlockNear(state.tr, state.doc.resolve(pos), paragraph);
+  view.dispatch(tr.scrollIntoView());
+};
+
+// After a node view for an upload is destroyed: when no node for it remains,
+// abort the request instead of letting it run for nothing.
+export const reconcileImageUpload = (view, id) => {
+  const entry = getUpload(id);
+  if (!entry) return;
+  const gone =
+    view.isDestroyed ||
+    !findUploadImages(view.state.doc, id, entry.objectUrl).length;
+  if (gone) abandonUpload(id);
+};
+
+// Insert image files as instant blob previews that swap in place to the
+// uploaded URL; failures keep the preview with retry/remove controls.
+// `upload` is (file, onProgress, signal) => Promise<url>.
+export const insertImageFiles = (view, files, { upload }) => {
+  const queue = Array.from(files).map((file) => ({
+    file,
+    id: newUploadId(),
+    objectUrl: URL.createObjectURL(file),
+  }));
+  queue.forEach(({ file, id, objectUrl }) => {
+    registerUpload(id, {
+      kind: "image",
+      name: file.name,
+      size: file.size,
+      objectUrl,
+      run: () => runImageUpload(view, id, fileRequest(id, file, upload), 0),
+      remove: () => deleteUploadImages(view, id),
+    });
+  });
+  // The caret can move while previews decode — anchor the insert point now.
+  const anchor = addInsertAnchor(view);
+  (async () => {
+    // Decode before inserting so the first paint has real dimensions;
+    // sequential so the nodes land in pick order.
+    for (const { id, objectUrl } of queue) {
+      await preloadImage(objectUrl, 3000);
+      if (!getUpload(id)) continue;
+      if (view.isDestroyed) {
+        releaseUpload(id);
+        continue;
+      }
+      insertImageNode(
+        view,
+        { src: objectUrl, uploadId: id },
+        insertAnchorPos(view, anchor)
+      );
+      getUpload(id).run();
+    }
+    dropInsertAnchor(view, anchor);
+  })();
+};
+
+// Mirror pasted external image URLs into storage. Images stay visible while
+// mirroring, duplicate URLs share one upload, and failures keep the image
+// with retry/remove controls. `upload` is (url, signal) => Promise<newUrl>.
+export const mirrorExternalImages = (view, urls, { upload }) => {
+  if (view.isDestroyed) return;
+  const unique = new Set(urls);
+  const assignments = new Map();
+  const tr = view.state.tr;
+  view.state.doc.descendants((node, pos) => {
+    if (node.type.name !== "image") return;
+    const src = node.attrs.src;
+    if (!unique.has(src) || node.attrs.uploadId) return;
+    let id = assignments.get(src);
+    if (!id) {
+      id = newUploadId();
+      assignments.set(src, id);
+    }
+    tr.setNodeMarkup(pos, null, { ...node.attrs, uploadId: id });
+  });
+  if (!assignments.size) return;
+  // Register before dispatching: node views read the registry synchronously
+  // while the uploadId transaction applies.
+  assignments.forEach((id, src) => {
+    registerUpload(id, {
+      kind: "image",
+      run: () => runImageUpload(view, id, (signal) => upload(src, signal)),
+      remove: () => deleteUploadImages(view, id),
+    });
+  });
+  view.dispatch(tr);
+  assignments.forEach((id) => getUpload(id).run());
+};
+
+// --- Videos: upload behind a widget-decoration progress card at the caret.
+// The card lives outside the document, so a half-finished upload can never be
+// autosaved; success inserts a paragraph linking the file name.
+
+const fileUploadKey = new PluginKey("fileUpload");
+
+// State holds the card decorations plus insert anchors: caret positions
+// captured when files arrive, mapped through edits so a delayed insert lands
+// where the user acted.
+export const fileUploadPlugin = () =>
+  new Plugin({
+    key: fileUploadKey,
+    state: {
+      init: () => ({ set: DecorationSet.empty, anchors: new Map() }),
+      apply(tr, value) {
+        const meta = tr.getMeta(fileUploadKey) || {};
+        let set = value.set.map(tr.mapping, tr.doc);
+        if (meta.add) set = set.add(tr.doc, [meta.add]);
+        if (meta.removeId) {
+          set = set.remove(
+            set.find(undefined, undefined, (s) => s.uploadId === meta.removeId)
+          );
+        }
+        let anchors = value.anchors;
+        if (anchors.size || meta.addAnchor) {
+          anchors = new Map();
+          value.anchors.forEach((pos, id) => anchors.set(id, tr.mapping.map(pos)));
+          if (meta.addAnchor) anchors.set(meta.addAnchor.id, meta.addAnchor.pos);
+          if (meta.dropAnchor) anchors.delete(meta.dropAnchor);
+        }
+        return { set, anchors };
+      },
+    },
+    props: {
+      decorations: (state) => fileUploadKey.getState(state).set,
+      // The card is a decoration, not a node — Backspace at its anchor would
+      // otherwise delete the doc content above the card.
+      handleKeyDown(view, event) {
+        const modified =
+          event.shiftKey || event.metaKey || event.ctrlKey || event.altKey;
+        if (event.key !== "Backspace" || modified) return false;
+        const { selection } = view.state;
+        if (!selection.empty) return false;
+        const hits = fileUploadKey
+          .getState(view.state)
+          .set.find(selection.from, selection.from);
+        if (!hits.length) return false;
+        removeUpload(hits[hits.length - 1].spec.uploadId);
+        return true;
+      },
+    },
+  });
+
+const addInsertAnchor = (view) => {
+  const id = newUploadId();
+  view.dispatch(
+    view.state.tr.setMeta(fileUploadKey, {
+      addAnchor: { id, pos: view.state.selection.from },
+    })
+  );
+  return id;
+};
+
+const insertAnchorPos = (view, id) =>
+  fileUploadKey.getState(view.state)?.anchors.get(id) ??
+  view.state.selection.from;
+
+const dropInsertAnchor = (view, id) => {
+  if (view.isDestroyed) return;
+  view.dispatch(view.state.tr.setMeta(fileUploadKey, { dropAnchor: id }));
+};
+
+const findUploadWidget = (view, id) => {
+  const found = fileUploadKey
+    .getState(view.state)
+    .set.find(undefined, undefined, (spec) => spec.uploadId === id);
+  return found.length ? found[0] : null;
+};
+
+// True while any upload in this view is still in flight — a rebuild would
+// destroy the placeholders and abort the requests. Failed uploads don't
+// count: an explicit external reset (e.g. discarding a draft) must win, and
+// the rebuild reconciles their leftovers away.
+export const hasActiveUploads = (view) => {
+  const inFlight = (id) => getUpload(id)?.status === "uploading";
+  const cards = fileUploadKey.getState(view.state)?.set.find() || [];
+  if (cards.some((deco) => inFlight(deco.spec.uploadId))) return true;
+  let found = false;
+  view.state.doc.descendants((node) => {
+    if (node.type.name === "image" && inFlight(node.attrs.uploadId)) {
+      found = true;
+    }
+    return !found;
+  });
+  return found;
+};
+
+const removeUploadWidget = (view, id) => {
+  if (view.isDestroyed) return;
+  view.dispatch(view.state.tr.setMeta(fileUploadKey, { removeId: id }));
+};
+
+// The link lands where the card was shown (which can be mid-textblock) and
+// carries the probed video dimensions so the embed reserves its exact box.
+const completeFileUpload = (view, id, url) =>
+  finishUpload(view, id, (entry) => {
+    const { state } = view;
+    const widget = findUploadWidget(view, id);
+    let tr = state.tr;
+    if (widget) {
+      let href = url;
+      if (entry.dimensions) {
+        const { width, height } = entry.dimensions;
+        href += `${href.includes("?") ? "&" : "?"}cw_video_ar=${width}x${height}`;
+      }
+      const mark = state.schema.marks.link.create({ href });
+      const paragraph = state.schema.nodes.paragraph.create(
+        null,
+        state.schema.text(entry.name || url, [mark])
+      );
+      tr = insertBlockNear(tr, state.doc.resolve(widget.from), paragraph);
+    }
+    view.dispatch(tr.setMeta(fileUploadKey, { removeId: id }));
+  });
+
+const reconcileFileUpload = (view, id) => {
+  if (!getUpload(id)) return;
+  if (view.isDestroyed || !findUploadWidget(view, id)) abandonUpload(id);
+};
+
+// Read the video's dimensions from the local file so the embed can reserve
+// its exact box from the first paint. Resolves null on failure or timeout.
+const probeVideoSize = (file) =>
+  new Promise((resolve) => {
+    const url = URL.createObjectURL(file);
+    const probe = document.createElement("video");
+    const done = (size) => {
+      clearTimeout(timer);
+      probe.removeAttribute("src");
+      URL.revokeObjectURL(url);
+      resolve(size);
+    };
+    const timer = setTimeout(() => done(null), 2000);
+    probe.preload = "metadata";
+    probe.onloadedmetadata = () =>
+      done(
+        probe.videoWidth && probe.videoHeight
+          ? { width: probe.videoWidth, height: probe.videoHeight }
+          : null
+      );
+    probe.onerror = () => done(null);
+    probe.src = url;
+  });
+
+// Upload video files with an inline progress card at the caret; on success
+// the card becomes a lone paragraph linking the file name to the uploaded URL
+// (the mp4 embed matches the href, so a player renders in its place).
+// `upload` is (file, onProgress, signal) => Promise<url>.
+export const insertFileUploads = (view, files, { upload }) => {
+  Array.from(files).forEach((file) => {
+    const id = newUploadId();
+    registerUpload(id, {
+      kind: "file",
+      name: file.name,
+      size: file.size,
+      run: () =>
+        runUpload(id, {
+          progress: 0,
+          request: fileRequest(id, file, upload),
+          complete: (url) => completeFileUpload(view, id, url),
+        }),
+      remove: () => removeUploadWidget(view, id),
+    });
+    probeVideoSize(file).then((dimensions) => {
+      if (dimensions) patchUpload(id, { dimensions });
+    });
+    const widget = Decoration.widget(
+      view.state.selection.from,
+      () => buildFileUploadCard(id),
+      {
+        uploadId: id,
+        key: id,
+        side: -1,
+        destroy: (dom) => {
+          dom.pmUploadCleanup?.();
+          queueMicrotask(() => reconcileFileUpload(view, id));
+        },
+      }
+    );
+    view.dispatch(view.state.tr.setMeta(fileUploadKey, { add: widget }));
+    getUpload(id).run();
+  });
+};

--- a/src/plugins/uploads.js
+++ b/src/plugins/uploads.js
@@ -304,8 +304,11 @@ const findUploadWidget = (view, id) => {
 // count: an explicit external reset (e.g. discarding a draft) must win, and
 // the rebuild reconciles their leftovers away.
 export const hasActiveUploads = (view) => {
+  const state = fileUploadKey.getState(view.state);
+  // Anchors exist while picked images decode, before their previews insert.
+  if (state?.anchors.size) return true;
   const inFlight = (id) => getUpload(id)?.status === "uploading";
-  const cards = fileUploadKey.getState(view.state)?.set.find() || [];
+  const cards = state?.set.find() || [];
   if (cards.some((deco) => inFlight(deco.spec.uploadId))) return true;
   let found = false;
   view.state.doc.descendants((node) => {

--- a/src/schema/article.js
+++ b/src/schema/article.js
@@ -18,7 +18,13 @@ tableNodeSpecs.table.parseDOM = [
 const baseImage = schema.spec.nodes.get('image');
 const image = {
   ...baseImage,
-  attrs: { ...baseImage.attrs, width: { default: null } },
+  // uploadId ties a node to an in-flight upload; it never reaches toDOM or
+  // the serializer, so it can't leak into saved content.
+  attrs: {
+    ...baseImage.attrs,
+    width: { default: null },
+    uploadId: { default: null },
+  },
   parseDOM: [{
     tag: 'img[src]',
     getAttrs: dom => ({

--- a/src/schema/markdown/serializer.js
+++ b/src/schema/markdown/serializer.js
@@ -158,6 +158,8 @@ export const paragraph = (state, node, parent, index) => {
   }
 };
 export const image = (state, node) => {
+  // blob: srcs are in-flight upload previews — autosaves must never capture them.
+  if ((node.attrs.src || '').startsWith('blob:')) return;
   let src = state.esc(node.attrs.src);
   if (node.attrs.height) {
     const param = `cw_image_height=${node.attrs.height}`;

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -594,6 +594,12 @@ li.ProseMirror-selectednode:after {
   display: none;
 }
 
+// Keyboard selection lands on the hidden source line; show it on the
+// preview widget that stands in for it (its next sibling in the DOM).
+.ProseMirror .cw-embed-source-hidden.ProseMirror-selectednode + .cw-embed-preview.cw-embed-preview--removable::after {
+  opacity: 1;
+}
+
 // Doubled class beats the app-side `.cw-embed-preview` max-width cap.
 .ProseMirror .cw-embed-preview.cw-embed-preview--removable {
   position: relative;

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -285,6 +285,12 @@ li.ProseMirror-selectednode:after {
     cursor: text;
   }
 
+  // Upload cards are widget decorations, so the doc still counts as empty
+  // while one is pending; hide the placeholder instead of painting under it.
+  p.empty-node:has(.pm-upload-card)::before {
+    content: none;
+  }
+
   // An image sits alone in its paragraph, so ProseMirror adds a trailing <br>
   // for the caret; with the 1.4 line-height that renders a blank line below the
   // image. Collapse it so the image sits flush (the image keeps its own height).
@@ -292,8 +298,7 @@ li.ProseMirror-selectednode:after {
     line-height: 0;
   }
 
-  // Image resize wrapper + diagonal handle (bottom-right corner). Shared by
-  // every editor variant that registers the imageResizeView NodeView.
+  // Image resize wrapper (any editor that registers imageResizeView).
   .pm-image-wrapper {
     position: relative;
     display: inline-block;
@@ -305,34 +310,343 @@ li.ProseMirror-selectednode:after {
     // to fill the wrapper so the corner handle stays anchored to its edge.
     &[style*="width"] img { width: 100%; }
 
-    // Subtle light-blue outline on hover so the image's edges
     &:hover { outline: 2px solid rgba(59, 130, 246, 0.5); outline-offset: -2px; }
 
-    .pm-image-resize-handle {
+    &:hover .pm-resize-handle,
+    &.ProseMirror-selectednode .pm-resize-handle { opacity: 1; }
+  }
+
+  // Corner resize chip shared by images and video embeds; the host wrapper's
+  // hover reveals it. The inset ring keeps it readable over dark video chrome.
+  .pm-resize-handle {
+    position: absolute;
+    inset-inline-end: 8px;
+    bottom: 8px;
+    display: grid;
+    place-items: center;
+    width: 22px;
+    height: 22px;
+    color: #fff;
+    background: rgb(17 18 20 / 0.75);
+    box-shadow: inset 0 0 0 1px rgb(255 255 255 / 0.4);
+    border-radius: 6px;
+    cursor: nwse-resize;
+    touch-action: none;
+    opacity: 0;
+    transition: opacity 0.12s, background 0.12s;
+
+    svg { width: 12px; height: 12px; pointer-events: none; }
+    &:hover { background: rgb(17 18 20 / 0.85); }
+
+    [dir="rtl"] & {
+      cursor: nesw-resize;
+      svg { transform: scaleX(-1); }
+    }
+  }
+}
+
+// Dashboard xs icon-only button recipe, shared by the upload chips.
+@mixin upload-chip($size) {
+  flex: none;
+  display: grid;
+  place-items: center;
+  width: $size;
+  height: $size;
+  padding: 0;
+  border: 0;
+  cursor: pointer;
+  transition: all 0.1s ease-out;
+
+  &:active { scale: 0.97; }
+}
+
+// Upload UI: the status pill over in-flight images and the video card.
+// Colors consume the dashboard tokens (--slate-*, --ruby-*) with light-theme
+// fallbacks; the pill keeps fixed dark glass — it sits over image pixels.
+.ProseMirror {
+  .pm-image-wrapper.pm-image-uploading .pm-resize-handle { display: none; }
+
+  // External mirrors have no local preview to define the box — reserve a
+  // footprint so the pill stays visible even if the source can't render.
+  .pm-image-wrapper.pm-image-uploading-external {
+    min-width: 220px;
+    min-height: 96px;
+    background: rgb(var(--slate-3, 240 240 243));
+  }
+
+  .pm-upload-overlay {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    overflow: visible;
+    background: rgb(17 18 20 / 0.32);
+    transition: opacity 0.18s ease;
+
+    &[data-state="error"] { background: rgb(17 18 20 / 0.52); }
+    &.pm-upload-done { opacity: 0; pointer-events: none; }
+  }
+
+  // On a small image the pill floats over the edges instead of squeezing.
+  .pm-upload-pill {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    width: max-content;
+    max-width: 300px;
+    padding: 8px 12px;
+    color: #fff;
+    font-size: 12px;
+    font-weight: var(--font-weight-medium);
+    line-height: 1.35;
+    background: rgb(17 18 20 / 0.82);
+    border-radius: 10px;
+    backdrop-filter: blur(4px);
+  }
+
+  .pm-upload-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    max-width: 100%;
+  }
+
+  .pm-upload-text {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  // Eight dots fading in sequence around a ring.
+  .pm-upload-spinner {
+    position: relative;
+    flex: none;
+    width: 14px;
+    height: 14px;
+
+    span {
       position: absolute;
-      inset-inline-end: 8px;
-      bottom: 8px;
-      display: grid;
-      place-items: center;
-      width: 22px;
-      height: 22px;
-      color: #fff;
-      background: rgba(0, 0, 0, 0.65);
-      border-radius: 6px;
-      cursor: nwse-resize;
-      opacity: 0;
-      transition: opacity 0.12s, background 0.12s;
-
-      svg { width: 12px; height: 12px; pointer-events: none; }
-      &:hover { background: rgba(0, 0, 0, 0.8); }
-
-      [dir="rtl"] & {
-        cursor: nesw-resize;
-        svg { transform: scaleX(-1); }
-      }
+      top: 0;
+      left: 50%;
+      width: 3px;
+      height: 3px;
+      margin-left: -1.5px;
+      border-radius: 50%;
+      background: currentColor;
+      opacity: 0.15;
+      transform-origin: 50% 7px;
+      animation: pm-upload-spinner-fade 0.8s ease-in-out infinite;
     }
 
-    &:hover .pm-image-resize-handle,
-    &.ProseMirror-selectednode .pm-image-resize-handle { opacity: 1; }
+    @for $i from 1 through 8 {
+      span:nth-child(#{$i}) {
+        transform: rotate(#{($i - 1) * 45}deg);
+        animation-delay: #{($i - 8) * 0.1}s;
+      }
+    }
   }
+
+  .pm-upload-cancel {
+    @include upload-chip(18px);
+    color: rgb(255 255 255 / 0.7);
+    background: rgb(255 255 255 / 0.12);
+    border-radius: 50%;
+
+    svg { width: 10px; height: 10px; }
+
+    &:hover,
+    &:focus-visible { color: #fff; background: rgb(255 255 255 / 0.24); }
+  }
+
+  // Error copy is longer — let it wrap, and swap cancel/spinner for retry/remove.
+  .pm-upload-overlay[data-state="error"] {
+    .pm-upload-text { white-space: normal; }
+    .pm-upload-spinner,
+    .pm-upload-cancel { display: none; }
+  }
+
+  .pm-upload-overlay:not([data-state="error"]) .pm-upload-actions { display: none; }
+
+  .pm-upload-actions {
+    display: inline-flex;
+    gap: 6px;
+  }
+
+  // Retry/remove after an error: ruby outline variant.
+  .pm-upload-action {
+    @include upload-chip(24px);
+    color: rgb(var(--ruby-11, 202 36 77));
+    background: transparent;
+    border-radius: 8px;
+    outline: 1px solid rgb(var(--ruby-8, 229 146 163));
+
+    svg { width: 16px; height: 16px; }
+
+    &:hover,
+    &:focus-visible { background: rgb(var(--ruby-9, 229 70 102) / 0.1); }
+  }
+
+  // The pill is fixed dark glass, so its chips use the dark-theme ruby values
+  // in both themes — the themed tokens would vanish over it in light mode.
+  .pm-upload-pill .pm-upload-action {
+    color: rgb(255 148 157);
+    outline-color: rgb(179 68 90);
+
+    &:hover,
+    &:focus-visible { background: rgb(229 70 102 / 0.2); }
+  }
+
+  .pm-upload-card {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px 10px;
+    max-width: 420px;
+    margin: 8px 0;
+    padding: 10px 12px;
+    line-height: 1.4;
+    color: rgb(var(--slate-12, 28 32 36));
+    background: rgb(var(--slate-2, 249 249 251));
+    border: 1px solid rgb(var(--slate-6, 217 217 224));
+    border-radius: 10px;
+    user-select: none;
+
+    &[data-state="error"] {
+      border-color: rgb(var(--ruby-9, 229 70 102) / 0.5);
+      background: rgb(var(--ruby-9, 229 70 102) / 0.05);
+
+      .pm-upload-cancel,
+      .pm-upload-spinner { display: none; }
+      .pm-upload-card-icon {
+        color: rgb(var(--ruby-9, 229 70 102));
+        background: rgb(var(--ruby-9, 229 70 102) / 0.12);
+      }
+      .pm-upload-card-meta { color: rgb(var(--ruby-9, 229 70 102)); }
+      .pm-upload-text { white-space: normal; }
+    }
+
+    &:not([data-state="error"]) .pm-upload-actions { display: none; }
+
+    // On the themed card the cancel is a slate ghost, not the glass circle.
+    .pm-upload-cancel {
+      width: 24px;
+      height: 24px;
+      color: rgb(var(--slate-11, 96 100 108));
+      background: transparent;
+      border-radius: 8px;
+
+      svg { width: 12px; height: 12px; }
+
+      &:hover,
+      &:focus-visible {
+        color: rgb(var(--slate-12, 28 32 36));
+        background: rgba(var(--alpha-2, 196, 197, 198, 0.22));
+      }
+    }
+  }
+
+  .pm-upload-card-icon {
+    flex: none;
+    display: grid;
+    place-items: center;
+    width: 32px;
+    height: 32px;
+    color: rgb(var(--slate-11, 96 100 108));
+    background: rgb(var(--slate-4, 232 232 236));
+    border-radius: 8px;
+
+    svg { width: 18px; height: 18px; }
+  }
+
+  .pm-upload-card-body {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 0;
+  }
+
+  .pm-upload-card-name {
+    overflow: hidden;
+    font-size: 13px;
+    font-weight: var(--font-weight-medium);
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  .pm-upload-card-meta {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+    color: rgb(var(--slate-11, 96 100 108));
+  }
+}
+
+@keyframes pm-upload-spinner-fade {
+  0% { opacity: 1; scale: 1; }
+  100% { opacity: 0.15; scale: 0.55; }
+}
+
+// hide_source embeds keep the raw link line in the doc for serialization but
+// out of sight; the preview widget handles selection and removal.
+.ProseMirror .cw-embed-source-hidden {
+  display: none;
+}
+
+// Doubled class beats the app-side `.cw-embed-preview` max-width cap.
+.ProseMirror .cw-embed-preview.cw-embed-preview--removable {
+  position: relative;
+  display: inline-block;
+  max-width: 100%;
+  // Template whitespace would add a line box below the player, pushing the
+  // corner controls outside the video. Same fix as .pm-image-wrapper.
+  line-height: 0;
+
+  // A plain outline never paints over the composited <video> layer; this
+  // positioned overlay ring paints above it, like the corner chips do.
+  &::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border: 2px solid rgba(59, 130, 246, 0.7);
+    opacity: 0;
+    transition: opacity 0.12s ease;
+    pointer-events: none;
+  }
+
+  &:hover::after { opacity: 1; }
+
+  video {
+    display: block;
+    max-width: 100%;
+    height: auto;
+  }
+
+  &[style*="width"] video { width: 100%; }
+
+  .cw-embed-remove {
+    @include upload-chip(24px);
+    position: absolute;
+    top: 8px;
+    inset-inline-end: 8px;
+    color: #fff;
+    background: rgb(17 18 20 / 0.75);
+    box-shadow: inset 0 0 0 1px rgb(255 255 255 / 0.4);
+    border-radius: 50%;
+    opacity: 0;
+    transition: opacity 0.12s ease;
+
+    svg { width: 11px; height: 11px; }
+
+    &:hover { background: rgb(17 18 20 / 0.85); }
+    &:focus-visible {
+      opacity: 1;
+      outline: 2px solid rgb(var(--blue-9, 39 129 246));
+      outline-offset: 1px;
+    }
+  }
+
+  &:hover .cw-embed-remove,
+  &:hover .pm-resize-handle { opacity: 1; }
 }

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -597,7 +597,10 @@ li.ProseMirror-selectednode:after {
 // Doubled class beats the app-side `.cw-embed-preview` max-width cap.
 .ProseMirror .cw-embed-preview.cw-embed-preview--removable {
   position: relative;
-  display: inline-block;
+  // Block so consecutive previews stack (the source lines between them are
+  // hidden); fit-content so the corner controls still hug the video.
+  display: block;
+  width: fit-content;
   max-width: 100%;
   // Template whitespace would add a line box below the player, pushing the
   // corner controls outside the video. Same fix as .pm-image-wrapper.

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -326,6 +326,8 @@ li.ProseMirror-selectednode:after {
     place-items: center;
     width: 22px;
     height: 22px;
+    padding: 0;
+    border: 0;
     color: #fff;
     background: rgb(17 18 20 / 0.75);
     box-shadow: inset 0 0 0 1px rgb(255 255 255 / 0.4);
@@ -337,6 +339,11 @@ li.ProseMirror-selectednode:after {
 
     svg { width: 12px; height: 12px; pointer-events: none; }
     &:hover { background: rgb(17 18 20 / 0.85); }
+    &:focus-visible {
+      opacity: 1;
+      outline: 2px solid rgb(var(--blue-9, 39 129 246));
+      outline-offset: 1px;
+    }
 
     [dir="rtl"] & {
       cursor: nesw-resize;

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -326,8 +326,6 @@ li.ProseMirror-selectednode:after {
     place-items: center;
     width: 22px;
     height: 22px;
-    padding: 0;
-    border: 0;
     color: #fff;
     background: rgb(17 18 20 / 0.75);
     box-shadow: inset 0 0 0 1px rgb(255 255 255 / 0.4);
@@ -339,11 +337,6 @@ li.ProseMirror-selectednode:after {
 
     svg { width: 12px; height: 12px; pointer-events: none; }
     &:hover { background: rgb(17 18 20 / 0.85); }
-    &:focus-visible {
-      opacity: 1;
-      outline: 2px solid rgb(var(--blue-9, 39 129 246));
-      outline-offset: 1px;
-    }
 
     [dir="rtl"] & {
       cursor: nesw-resize;

--- a/test/uploads.spec.js
+++ b/test/uploads.spec.js
@@ -1,15 +1,21 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EditorState } from 'prosemirror-state';
 
-import { fileUploadPlugin, insertFileUploads } from '../src/plugins/uploads';
+import {
+  fileUploadPlugin,
+  hasActiveUploads,
+  insertFileUploads,
+  insertImageFiles,
+} from '../src/plugins/uploads';
 import { getUpload } from '../src/plugins/uploadState';
+import { fullSchema } from '../src/schema/article';
 import { messageSchema } from '../src/schema/message';
 
-// insertFileUploads only touches state/dispatch/isDestroyed, so a functional
+// The upload pipelines only touch state/dispatch/isDestroyed, so a functional
 // fake view keeps this headless — the widget's toDOM is lazy and never runs.
-const makeView = plugin => {
+const makeView = (plugin, schema = messageSchema) => {
   const view = {
-    state: EditorState.create({ schema: messageSchema, plugins: [plugin] }),
+    state: EditorState.create({ schema, plugins: [plugin] }),
     isDestroyed: false,
     dispatch(tr) {
       view.state = view.state.apply(tr);
@@ -53,5 +59,45 @@ describe('insertFileUploads', () => {
     const cards = plugin.getState(view.state).set.find();
     expect(cards).toHaveLength(1);
     expect(getUpload(cards[0].spec.uploadId).status).toBe('error');
+  });
+});
+
+describe('insertImageFiles', () => {
+  const decodes = [];
+  class FakeImage {
+    decode() {
+      return new Promise(resolve => decodes.push(resolve));
+    }
+  }
+
+  beforeEach(() => {
+    decodes.length = 0;
+    vi.stubGlobal('Image', FakeImage);
+    vi.stubGlobal('URL', { createObjectURL: () => 'blob:test' });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('counts a picked image as active while it is still decoding', async () => {
+    const plugin = fileUploadPlugin();
+    // The article schema declares the uploadId attr the image pipeline uses.
+    const view = makeView(plugin, fullSchema);
+    insertImageFiles(view, [{ name: 'pic.png', size: 1 }], {
+      upload: () => new Promise(() => {}),
+    });
+
+    // No node or card exists yet — the insert anchor covers this window.
+    expect(hasActiveUploads(view)).toBe(true);
+
+    decodes[0]();
+    await settle();
+    const images = [];
+    view.state.doc.descendants(node => {
+      if (node.type.name === 'image') images.push(node);
+    });
+    expect(images).toHaveLength(1);
+    expect(hasActiveUploads(view)).toBe(true);
   });
 });

--- a/test/uploads.spec.js
+++ b/test/uploads.spec.js
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { EditorState } from 'prosemirror-state';
+
+import { fileUploadPlugin, insertFileUploads } from '../src/plugins/uploads';
+import { getUpload } from '../src/plugins/uploadState';
+import { messageSchema } from '../src/schema/message';
+
+// insertFileUploads only touches state/dispatch/isDestroyed, so a functional
+// fake view keeps this headless — the widget's toDOM is lazy and never runs.
+const makeView = plugin => {
+  const view = {
+    state: EditorState.create({ schema: messageSchema, plugins: [plugin] }),
+    isDestroyed: false,
+    dispatch(tr) {
+      view.state = view.state.apply(tr);
+    },
+  };
+  return view;
+};
+
+const settle = () => new Promise(resolve => setTimeout(resolve));
+
+describe('insertFileUploads', () => {
+  it('flushes a finished file when the upload ahead of it fails', async () => {
+    const plugin = fileUploadPlugin();
+    const view = makeView(plugin);
+    const pending = new Map();
+    const upload = file =>
+      new Promise((resolve, reject) =>
+        pending.set(file.name, { resolve, reject })
+      );
+
+    insertFileUploads(
+      view,
+      [
+        { name: 'first.mp4', size: 1 },
+        { name: 'second.mp4', size: 1 },
+      ],
+      { upload }
+    );
+    await settle();
+
+    // The finished second file waits behind first to keep pick order.
+    pending.get('second.mp4').resolve('https://cdn.example.com/second.mp4');
+    await settle();
+    expect(view.state.doc.textContent).not.toContain('second.mp4');
+
+    pending.get('first.mp4').reject(new Error('boom'));
+    await settle();
+    expect(view.state.doc.textContent).toContain('second.mp4');
+
+    // The failed card stays for retry/remove.
+    const cards = plugin.getState(view.state).set.find();
+    expect(cards).toHaveLength(1);
+    expect(getUpload(cards[0].spec.uploadId).status).toBe('error');
+  });
+});


### PR DESCRIPTION
## Description

This PR improves the upload and video embed experience in the article editor. Images now appear immediately with upload progress and retry support, while video uploads show an inline progress card and become resizable video players once uploaded.

It also handles failed uploads without losing the placeholder, supports cancelling in-flight uploads, and prevents external state updates from overwriting uploads that are still in progress. Video embeds keep their size and aspect ratio across reloads and show a retryable state when they fail to load.

### What changed

* Added upload pipelines for images and videos with progress, cancel, retry, and remove support.
* Added instant blob previews for images and in-place replacement after upload.
* Added support for mirroring pasted external images without flicker or duplicate uploads.
* Added inline video upload cards with positions mapped through editor changes.
* Added video remove and corner resize support with persisted width and aspect ratio.
* Added guards to prevent in-flight uploads from being overwritten by external state updates.
* Added retry support for videos that fail while offline and automatic recovery when the connection returns.
* Prevented unfinished `blob:` image previews from being persisted during autosave.
* Fixed mention/slash suggestions appearing incorrectly across node boundaries.
