### PR TITLE
fix: encode empty lines and hard breaks without backslash artifacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatwoot/prosemirror-schema",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "Schema setup for using prosemirror in chatwoot. Based on 👉 https://github.com/ProseMirror/prosemirror-example-setup/",
   "main": "dist/index.es.js",
   "scripts": {

--- a/src/keymap.js
+++ b/src/keymap.js
@@ -290,13 +290,12 @@ export function baseKeyMaps(schema) {
   if (schema.nodes.hard_break) {
     let br = schema.nodes.hard_break,
       cmd = chainCommands(exitCode, (state, dispatch) => {
-        // inheritMarks: false — a break inheriting an active link mark used
-        // to serialize as a link around the backslash and break parsing (the
-        // old workaround inserted a space before every break instead, which
-        // polluted messages with trailing spaces)
-        dispatch(
-          state.tr.replaceSelectionWith(br.create(), false).scrollIntoView()
-        );
+        // Upstream-default break insertion (marks inherited, so bold/italic
+        // continue across Shift+Enter). An old workaround inserted a space
+        // before every break to keep link marks off it, polluting messages
+        // with trailing spaces — the serializer now closes and reopens marks
+        // around breaks, so marked breaks serialize cleanly without it.
+        dispatch(state.tr.replaceSelectionWith(br.create()).scrollIntoView());
         return true;
       });
     bind('Mod-Enter', cmd);

--- a/src/keymap.js
+++ b/src/keymap.js
@@ -290,11 +290,12 @@ export function baseKeyMaps(schema) {
   if (schema.nodes.hard_break) {
     let br = schema.nodes.hard_break,
       cmd = chainCommands(exitCode, (state, dispatch) => {
+        // inheritMarks: false — a break inheriting an active link mark used
+        // to serialize as a link around the backslash and break parsing (the
+        // old workaround inserted a space before every break instead, which
+        // polluted messages with trailing spaces)
         dispatch(
-          state.tr
-            .insertText(` `)
-            .replaceSelectionWith(br.create())
-            .scrollIntoView()
+          state.tr.replaceSelectionWith(br.create(), false).scrollIntoView()
         );
         return true;
       });

--- a/src/schema/markdown/articleSerializer.js
+++ b/src/schema/markdown/articleSerializer.js
@@ -23,8 +23,16 @@ import {
   link,
   code,
 } from './serializer';
+import { splitTrailingBreaks } from './serializer';
 
-export const ArticleMarkdownSerializer = new MarkdownSerializerBase(
+// Same normalization as MessageMarkdownSerializer (see splitTrailingBreaks)
+class NormalizingMarkdownSerializer extends MarkdownSerializerBase {
+  serialize(content, options) {
+    return super.serialize(splitTrailingBreaks(content), options);
+  }
+}
+
+export const ArticleMarkdownSerializer = new NormalizingMarkdownSerializer(
   {
     blockquote,
     code_block,

--- a/src/schema/markdown/messageSerializer.js
+++ b/src/schema/markdown/messageSerializer.js
@@ -18,8 +18,17 @@ import {
   link,
   code,
 } from './serializer';
+import { splitTrailingBreaks } from './serializer';
 
-export const MessageMarkdownSerializer = new MarkdownSerializerBase(
+// Normalizes the doc before serializing so every empty visual line reaches
+// the node serializers in one canonical shape (see splitTrailingBreaks)
+class NormalizingMarkdownSerializer extends MarkdownSerializerBase {
+  serialize(content, options) {
+    return super.serialize(splitTrailingBreaks(content), options);
+  }
+}
+
+export const MessageMarkdownSerializer = new NormalizingMarkdownSerializer(
   {
     mention,
     blockquote,

--- a/src/schema/markdown/serializer.js
+++ b/src/schema/markdown/serializer.js
@@ -53,13 +53,15 @@ const adjacentToBlock = (parent, index) =>
 // The visual line starting at `start`: its text (joining consecutive text
 // siblings, since marks split a line into multiple text nodes) and whether
 // that run closes the line — an atom sibling (image/mention) continues it.
+// A whitespace-only marked node does not count as marked: the serializer
+// expels enclosing whitespace, so it emits no mark syntax into the line.
 const lineFrom = (parent, start) => {
   const rest = childrenOf(parent).slice(start);
   const stop = rest.findIndex(child => !child.isText);
   const run = stop < 0 ? rest : rest.slice(0, stop);
   return {
     text: run.map(child => child.text).join(''),
-    marked: run.some(child => child.marks.length > 0),
+    marked: run.some(child => child.marks.length > 0 && child.text.trim()),
     closed: stop < 0 || rest[stop].type.name === 'hard_break',
   };
 };
@@ -210,6 +212,9 @@ export const paragraph = (state, node, parent, index) => {
   if (isUnderline(nextLine)) {
     return state.write(isEmptyParagraph(parent.child(index + 1)) ? '\\\n' : '\\\n\\');
   }
+  // An underline the escape cannot reach (indented) must not be glued either —
+  // it would read the glue line as a heading. Detach it with a plain newline.
+  if (isIndentedUnderline(nextLine)) return state.write('\n');
   state.write(startsWithMarkdownSyntax(nextLine.text) ? '\n' : '\\\n');
 };
 export const image = (state, node) => {

--- a/src/schema/markdown/serializer.js
+++ b/src/schema/markdown/serializer.js
@@ -1,87 +1,133 @@
-// Block elements that handle their own spacing (no backslash needed adjacent to these)
+import { Fragment } from 'prosemirror-model';
+
+// Blocks that manage their own spacing — empty lines next to them need no glue
 const BLOCK_TYPES = new Set(['blockquote', 'code_block', 'bullet_list', 'ordered_list', 'heading', 'horizontal_rule', 'table']);
 
 const MARKDOWN_PATTERNS = {
-  // CommonMark list markers: "* ", "- ", "+ " or "1. ", "1) " (up to 9 digits)
-  // Bare marker at end also counts (rest of line may be image/mention nodes)
+  // List markers: "* ", "- ", "+ ", "1. ", "1) " — bare marker at line end included
   list: /^([*\-+]|\d{1,9}[.)])(\s|$)/,
-  // Block-level markdown syntax that should not be preceded by backslash
-  // Includes: blockquote (>), ATX headings (#), fenced code (``` or ~~~), thematic breaks (--, ---, ***, ___)
-  blockStart: /^(>\s?|#{1,6}\s|```|~~~|[-*_]{2,}$)/,
-  // Markdown table rows: lines starting with "|" (data rows, header rows, separator rows like |---|)
+  // Block starters: blockquote, ATX heading (a bare "#" is a valid empty
+  // heading and interrupts a paragraph), code fence, thematic break
+  blockStart: /^(>\s?|#{1,6}(\s|$)|```|~~~|[-*_]{2,}$)/,
   tableRow: /^\|/,
+  // Setext underline: a line of only "-" or "=" characters. cmark reads the
+  // line above it as a heading (`a\n-` → <h2>a</h2>), so glue backslashes
+  // must never sit on top of one unescaped.
+  setextUnderline: /^(-+|=+)[ \t]*$/,
+  // CommonMark also accepts an underline indented by 1-3 spaces. The escape
+  // cannot be glued onto those (the `\` would land before the spaces), so
+  // they detach with a blank line instead.
+  indentedSetextUnderline: /^ {1,3}(-+|=+)[ \t]*$/,
+  // A lone dash doubles as a bullet marker — it is a real list when inline
+  // content (image/mention) follows it on the same line.
+  soloDash: /^-[ \t]*$/,
 };
 
-/**
- * Checks if a paragraph node is empty (no visible content).
- * Empty = no trimmed text AND (no children OR only whitespace text nodes)
- * Edge cases handled:
- * - Truly empty: <p></p> → true
- * - Whitespace only: <p>   </p> → true
- * - Has image/mention: <p><image/></p> → false (not empty)
- * - Has text: <p>hello</p> → false (not empty)
- */
-const isEmptyParagraph = node => {
-  if (node.type.name !== 'paragraph') return false;
-  if (!node.textContent.trim()) {
-    // No visible text - verify it only contains text nodes (not images/mentions/etc.)
-    for (let i = 0; i < node.childCount; i++) {
-      if (!node.child(i).isText) return false;
-    }
-    return true;
-  }
-  return false;
-};
+const childrenOf = node => Array.from({ length: node.childCount }, (_, i) => node.child(i));
 
-/**
- * Checks if text starts with markdown syntax that should not be preceded by backslash.
- * Combines list syntax and block syntax detection for efficiency.
- * Detects:
- * - List markers: *, -, +, 1., 2), etc.
- * - Blockquotes: >
- * - Headings: #, ##, ###, etc.
- * - Code fences: ```, ~~~
- * - Thematic breaks: ---, ***, ___
- */
+// An empty visual line: no visible text, only whitespace / hard_break children.
+// Unifies Enter (empty paragraph) and Shift+Enter (break-only paragraph).
+const isEmptyParagraph = node =>
+  node.type.name === 'paragraph' &&
+  !node.textContent.trim() &&
+  childrenOf(node).every(child => child.isText || child.type.name === 'hard_break');
+
+// Markdown syntax that must start its own line — never glue a `\` before it
 const startsWithMarkdownSyntax = text => {
-  if (!text) return false;
-  const trimmed = text.trim();
+  const trimmed = (text || '').trim();
   return MARKDOWN_PATTERNS.list.test(trimmed) || MARKDOWN_PATTERNS.blockStart.test(trimmed) || MARKDOWN_PATTERNS.tableRow.test(trimmed);
 };
 
-// Find first non-empty sibling (skips multiple empty paragraphs)
-// dir: 1 = next, -1 = prev | Returns node type name or null
+// Nearest non-empty sibling in a direction (1 = next, -1 = prev); null if none
 const findNonEmptySibling = (parent, index, dir) => {
-  for (let i = index + dir; dir > 0 ? i < parent.childCount : i >= 0; i += dir) {
-    const child = parent.child(i);
-    if (!isEmptyParagraph(child)) return child.type.name;
+  for (let i = index + dir; i >= 0 && i < parent.childCount; i += dir) {
+    if (!isEmptyParagraph(parent.child(i))) return parent.child(i);
   }
   return null;
 };
 
-// True if nearest non-empty sibling (either direction) is a block element
-// Edge case: multiple empty paragraphs before block → all skip backslash
 const adjacentToBlock = (parent, index) =>
-  BLOCK_TYPES.has(findNonEmptySibling(parent, index, 1)) ||
-  BLOCK_TYPES.has(findNonEmptySibling(parent, index, -1));
+  BLOCK_TYPES.has(findNonEmptySibling(parent, index, 1)?.type.name) ||
+  BLOCK_TYPES.has(findNonEmptySibling(parent, index, -1)?.type.name);
 
-// Full line text from `start` — joins consecutive text siblings, since marks
-// (link/bold) split a line into multiple text nodes ("- " + linked url)
-const lineTextFrom = (parent, start) => {
-  let text = '';
-  for (let i = start; i < parent.childCount && parent.child(i).isText; i++) {
-    text += parent.child(i).text;
-  }
-  return text;
+// The visual line starting at `start`: its text (joining consecutive text
+// siblings, since marks split a line into multiple text nodes) and whether
+// that run closes the line — an atom sibling (image/mention) continues it.
+const lineFrom = (parent, start) => {
+  const rest = childrenOf(parent).slice(start);
+  const stop = rest.findIndex(child => !child.isText);
+  const run = stop < 0 ? rest : rest.slice(0, stop);
+  return {
+    text: run.map(child => child.text).join(''),
+    marked: run.some(child => child.marks.length > 0),
+    closed: stop < 0 || rest[stop].type.name === 'hard_break',
+  };
 };
 
-// True if any sibling after `start` has content (text or children)
-const hasContentAfter = (parent, start) => {
-  for (let i = start; i < parent.childCount; i++) {
-    const child = parent.child(i);
-    if (child.childCount || child.textContent.trim()) return true;
-  }
-  return false;
+// A line cmark could read as a setext underline for the line above it, in a
+// form the escape can neutralize (unmarked, unindented — the `\` must land
+// right before the first dash). A lone dash counts only when it closes its
+// line — followed by inline content it is a real bullet marker instead.
+const isUnderline = ({ text, closed, marked }) =>
+  !marked &&
+  MARKDOWN_PATTERNS.setextUnderline.test(text) &&
+  (closed || !MARKDOWN_PATTERNS.soloDash.test(text));
+
+// Marked dashes serialize wrapped in mark syntax (**--**, `--`), which can
+// never form an underline — plain glue is safe and keeps the formatting.
+const isMarkedUnderline = ({ text, marked }) =>
+  marked && MARKDOWN_PATTERNS.setextUnderline.test(text.trim());
+
+// An unmarked underline the escape cannot reach: indented 1-3 spaces (still
+// a valid underline to cmark) — only a blank line detaches it safely.
+const isIndentedUnderline = ({ text, marked }) =>
+  !marked && MARKDOWN_PATTERNS.indentedSetextUnderline.test(text);
+
+// Trailing hard_break run of a paragraph (Shift+Enter presses at the end).
+// Whitespace-only text inside the run belongs to it — the old keymap paired
+// every break with a space. Returns the break count and the size it spans.
+const trailingBreakRun = node => {
+  const isBreak = child => child.type.name === 'hard_break';
+  const reversed = childrenOf(node).reverse();
+  const stop = reversed.findIndex(child => !isBreak(child) && !(child.isText && !child.text.trim()));
+  const tail = stop < 0 ? reversed : reversed.slice(0, stop);
+  const run = tail.slice(0, tail.map(isBreak).lastIndexOf(true) + 1);
+  return {
+    breaks: run.filter(isBreak).length,
+    size: run.reduce((total, child) => total + child.nodeSize, 0),
+  };
+};
+
+// First inline child is an atom (image/mention/tools). Never write glue before
+// these: chatwoot's signature machinery compares serializations byte for byte,
+// and the live editor's image isolation and the parser disagree about the
+// preceding empty paragraph — both sides only match when neither writes glue.
+const startsWithAtom = node => {
+  const first = node.firstChild;
+  return Boolean(first) && !first.isText && first.type.name !== 'hard_break';
+};
+
+/**
+ * Pre-serialization normalization: reduce every empty visual line to ONE
+ * canonical shape — the empty paragraph — so the serializer has a single
+ * case to encode. Trailing hard_breaks of a top-level paragraph split off
+ * into sibling empty paragraphs; a break-only paragraph becomes empty
+ * paragraphs outright. Breaks with text after them stay untouched, as does
+ * anything nested inside blockquotes, lists and tables.
+ */
+export const splitTrailingBreaks = doc => {
+  const paragraphType = doc.type.schema.nodes.paragraph;
+  const runFor = node => (node.type === paragraphType ? trailingBreakRun(node) : { breaks: 0 });
+  if (!childrenOf(doc).some(node => runFor(node).breaks)) return doc;
+
+  const blocks = childrenOf(doc).flatMap(node => {
+    const { breaks, size } = runFor(node);
+    if (!breaks) return node;
+    const rest = node.cut(0, node.content.size - size);
+    const empties = Array.from({ length: breaks }, () => paragraphType.create());
+    return isEmptyParagraph(rest) ? empties : [rest, ...empties];
+  });
+  return doc.copy(Fragment.from(blocks));
 };
 
 /**
@@ -141,21 +187,30 @@ export const list_item = (state, node) => {
   state.renderContent(node);
 };
 
-// Paragraph (Enter key)
-// Fixes: Unwanted backslash appearing before blocks or in empty lines
-// - Empty near block (list/blockquote/code) → "\n" (no backslash)
-// - Empty between text → "\\\n" (preserves blank line)
-// - Trailing empty / signature removed → "\n" (no literal "\")
-// - Single empty doc → nothing | In table → normal render
+// A non-empty paragraph serializes normally. An empty one (docs are
+// normalized first, see splitTrailingBreaks) is an empty visual line,
+// encoded as a `\` hard-break line glued to the next paragraph — the only
+// shape CommonMark round-trips, since blank lines collapse. Glue is skipped
+// where it would be misread: sole/leading/trailing position and atom-led
+// paragraphs get nothing, blocks and block-markdown lines get plain "\n",
+// and above a "--"/"==" underline the chain ends in "\\\n\\" so the escaped
+// underline cannot form a setext heading.
 export const paragraph = (state, node, parent, index) => {
-  if (isEmptyParagraph(node) && !state.inTable) {
-    if (parent.childCount === 1) return;
-    if (adjacentToBlock(parent, index)) return state.write('\n');
-    state.write(index > 0 && hasContentAfter(parent, index + 1) ? '\\\n' : '\n');
-  } else {
+  if (!isEmptyParagraph(node) || state.inTable) {
     state.renderInline(node);
     state.closeBlock(node);
+    return;
   }
+  if (parent.childCount === 1) return;
+  if (adjacentToBlock(parent, index)) return state.write('\n');
+  const next = findNonEmptySibling(parent, index, 1);
+  if (index === 0 || !next || startsWithAtom(next)) return;
+  const nextLine = lineFrom(next, 0);
+  if (isMarkedUnderline(nextLine)) return state.write('\\\n');
+  if (isUnderline(nextLine)) {
+    return state.write(isEmptyParagraph(parent.child(index + 1)) ? '\\\n' : '\\\n\\');
+  }
+  state.write(startsWithMarkdownSyntax(nextLine.text) ? '\n' : '\\\n');
 };
 export const image = (state, node) => {
   // blob: srcs are in-flight upload previews — autosaves must never capture them.
@@ -189,25 +244,31 @@ export const image = (state, node) => {
   );
 };
 
-// Hard break (Shift+Enter)
-// Fixes: Backslash only when followed by actual text, not on empty/trailing lines
-// - Text after → "\\\n" (line break works correctly)
-// - List syntax after ("* ", "1. ") → "\n" (user typing list)
-// - Block syntax after (">", "#", etc.) → "\n" (user typing blockquote/heading)
-// - List/block syntax split by marks ("- " + linked url) → "\n" (full line tested)
-// - Multiple hard_breaks without content → "\n" (no stray backslash)
-// - Trailing / no content after → "\n" (no literal "\" showing)
+// Hard break (Shift+Enter). Writes "\\\n" only when real content follows on
+// a later line; bare/trailing breaks write plain "\n" so no literal backslash
+// ever shows. A line of block-markdown syntax ("* ", ">", "#"…) gets "\n"
+// too, and the break directly above a "--"/"==" underline writes "\\\n\\" to
+// escape it — unless whitespace text sits between them, which would detach
+// the escape.
 export const hard_break = (state, node, parent, index) => {
-  for (let i = index + 1; i < parent.childCount; i++) {
-    const sibling = parent.child(i);
-    if (sibling.type.name === 'hard_break') continue;
-    if (sibling.isText) {
-      if (!sibling.text.trim()) continue;
-      return state.write(startsWithMarkdownSyntax(lineTextFrom(parent, i)) ? '\n' : '\\\n');
-    }
-    return state.write('\\\n');
+  const siblings = childrenOf(parent).slice(index + 1);
+  const isFiller = child => child.type.name === 'hard_break' || (child.isText && !child.text.trim());
+  const nextAt = siblings.findIndex(child => !isFiller(child));
+  if (nextAt < 0) return state.write('\n');
+
+  const next = siblings[nextAt];
+  if (!next.isText) return state.write('\\\n');
+  const line = lineFrom(parent, index + 1 + nextAt);
+  const skippedWhitespace = siblings.slice(0, nextAt).some(child => child.isText);
+  if (isMarkedUnderline(line)) return state.write('\\\n');
+  if (isUnderline(line) && !skippedWhitespace) {
+    return state.write(nextAt === 0 ? '\\\n\\' : '\\\n');
   }
-  state.write('\n');
+  // An underline the escape cannot reach (indented, or detached from the
+  // break by whitespace text) would still bind as a heading over this line —
+  // a blank line is the only safe separator.
+  if (isIndentedUnderline(line) || isUnderline(line)) return state.write('\n\n');
+  state.write(startsWithMarkdownSyntax(line.text) ? '\n' : '\\\n');
 };
 export const text = (state, node) => {
   state.text(node.text, false);

--- a/test/serializer.spec.js
+++ b/test/serializer.spec.js
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
+import MarkdownIt from 'markdown-it';
 
 import { MessageMarkdownSerializer } from '../src/schema/markdown/messageSerializer';
+import { MessageMarkdownTransformer } from '../src/schema/markdown/messageParser';
 import { ArticleMarkdownSerializer } from '../src/schema/markdown/articleSerializer';
 import { messageSchema } from '../src/schema/message';
 import { fullSchema } from '../src/schema/article';
@@ -37,11 +39,20 @@ describe('hard_break', () => {
     }
   );
 
-  it.each(['> quoted', '# heading', '``` code', '---'])(
+  it.each(['> quoted', '# heading', '#', '######', '``` code', '***'])(
     'skips the backslash when the next line starts block syntax "%s"',
     line => {
       expect(serialize(doc(p(t('intro'), br(), t(line))))).toBe(
         `intro\n${line}`
+      );
+    }
+  );
+
+  it.each(['-', '- ', '--', '---', '=', '=='])(
+    'escapes the setext underline "%s" after a hard break',
+    line => {
+      expect(serialize(doc(p(t('intro'), br(), t(line))))).toBe(
+        `intro\\\n\\${line}`
       );
     }
   );
@@ -67,6 +78,20 @@ describe('hard_break', () => {
     expect(result).toBe('note\n- **important**');
   });
 
+  it('detaches an indented setext underline with a blank line', () => {
+    expect(serialize(doc(p(t('a'), br(), t('  --'))))).toBe('a\n\n  --');
+  });
+
+  it('detaches an underline separated from the break by whitespace text', () => {
+    expect(serialize(doc(p(t('a'), br(), t(' '), t('=='))))).toBe('a\n\n ==');
+  });
+
+  it('writes plain glue for a bold underline — mark syntax defuses it', () => {
+    expect(serialize(doc(p(t('a'), br(), t('--', [mark('strong')]))))).toBe(
+      'a\\\n**--**'
+    );
+  });
+
   it('keeps the backslash for a mid-sentence link that is not a list', () => {
     const result = serialize(
       doc(p(t('see'), br(), t('this '), t(URL, [mark('link', { href: URL })])))
@@ -74,8 +99,51 @@ describe('hard_break', () => {
     expect(result).toBe(`see\\\nthis <${URL}>`);
   });
 
-  it('writes a plain newline for a trailing hard break', () => {
-    expect(serialize(doc(p(t('hello'), br())))).toBe('hello\n');
+  it('drops a trailing hard break at the end of the document', () => {
+    expect(serialize(doc(p(t('hello'), br())))).toBe('hello');
+  });
+
+  it('preserves trailing hard breaks before the next paragraph', () => {
+    expect(serialize(doc(p(t('a'), br(), br()), p(t('b'))))).toBe(
+      'a\n\n\\\n\\\nb'
+    );
+  });
+
+  it('escapes the underline after trailing hard breaks', () => {
+    expect(serialize(doc(p(t('a'), br(), br()), p(t('--'))))).toBe(
+      'a\n\n\\\n\\\n\\--'
+    );
+  });
+
+  it('chains trailing hard breaks with empty paragraphs before a signature', () => {
+    expect(
+      serialize(doc(p(t('sdsd'), br(), br()), p(), p(t('--')), p(t('Thanks'))))
+    ).toBe('sdsd\n\n\\\n\\\n\\\n\\--\n\nThanks');
+  });
+
+  it('drops trailing hard breaks before a list', () => {
+    const list = messageSchema.node('bullet_list', null, [
+      messageSchema.node('list_item', null, [p(t('item'))]),
+    ]);
+    expect(serialize(doc(p(t('a'), br()), list))).toBe('a\n\n\n* item');
+  });
+
+  it('keeps every break of a multi-break run before an underline', () => {
+    expect(serialize(doc(p(t('a'), br(), br(), t('--'))))).toBe(
+      'a\\\n\\\n\\--'
+    );
+  });
+
+  it('treats legacy space-padded trailing breaks as a clean run', () => {
+    expect(
+      serialize(doc(p(t('zz '), br(), t(' '), br()), p(t('--')), p(t('Thanks'))))
+    ).toBe('zz \n\n\\\n\\\n\\--\n\nThanks');
+  });
+
+  it('absorbs whitespace after the last trailing break', () => {
+    expect(serialize(doc(p(t('a'), br(), t('  ')), p(t('b'))))).toBe(
+      'a\n\n\\\nb'
+    );
   });
 
   it('writes backslash breaks for consecutive hard breaks before text', () => {
@@ -140,14 +208,184 @@ describe('paragraph', () => {
     expect(serialize(doc(list, p(), p(t('b'))))).toBe('* item\n\n\nb');
   });
 
-  it('drops the backslash on a trailing empty paragraph', () => {
-    expect(serialize(doc(p(t('a')), p()))).toBe('a\n\n\n');
+  it('drops a trailing empty paragraph entirely', () => {
+    expect(serialize(doc(p(t('a')), p()))).toBe('a');
   });
 
   it('treats a whitespace-only paragraph as empty', () => {
     expect(serialize(doc(p(t('a')), p(t('   ')), p(t('b'))))).toBe(
       'a\n\n\\\nb'
     );
+  });
+
+  it('serializes a break-only paragraph like an empty paragraph', () => {
+    expect(serialize(doc(p(t('a')), p(br()), p(t('b'))))).toBe('a\n\n\\\nb');
+  });
+
+  it('does not strand a backslash before trailing empty-ish paragraphs', () => {
+    expect(serialize(doc(p(t('a')), p(), p(br())))).toBe('a');
+  });
+
+  it('does not strand a backslash before a trailing whitespace paragraph', () => {
+    expect(serialize(doc(p(t('a')), p(), p(t('  '))))).toBe('a');
+  });
+
+  it('escapes a setext dash underline below an empty paragraph', () => {
+    expect(serialize(doc(p(t('a')), p(), p(t('--'))))).toBe('a\n\n\\\n\\--');
+  });
+
+  it('escapes a lone dash below an empty paragraph', () => {
+    expect(serialize(doc(p(t('a')), p(), p(t('-'))))).toBe('a\n\n\\\n\\-');
+  });
+
+  it('keeps glue before a bold underline below an empty line', () => {
+    expect(serialize(doc(p(t('a')), p(), p(t('--', [mark('strong')]))))).toBe(
+      'a\n\n\\\n**--**'
+    );
+  });
+
+  it('keeps a lone dash as a list marker when an image continues its line', () => {
+    const img = messageSchema.node('image', { src: 'https://x.co/a.png' });
+    expect(serialize(doc(p(t('a')), p(), p(t('- '), img)))).toBe(
+      'a\n\n\n- ![](https://x.co/a.png)'
+    );
+  });
+
+  it('escapes a setext equals underline below an empty paragraph', () => {
+    expect(serialize(doc(p(t('a')), p(), p(t('=='))))).toBe('a\n\n\\\n\\==');
+  });
+
+  it('only the last empty line before the underline carries the escape', () => {
+    expect(serialize(doc(p(t('a')), p(), p(), p(t('--'))))).toBe(
+      'a\n\n\\\n\\\n\\--'
+    );
+  });
+
+  it('keeps empty lines above a signature without stranding a backslash', () => {
+    expect(
+      serialize(doc(p(t('hey')), p(), p(br()), p(t('--')), p(t('Thanks'))))
+    ).toBe('hey\n\n\\\n\\\n\\--\n\nThanks');
+  });
+
+  it('drops the backslash when the next paragraph starts with list syntax', () => {
+    expect(serialize(doc(p(t('a')), p(), p(t('- pasted'))))).toBe(
+      'a\n\n\n- pasted'
+    );
+  });
+
+  it('silently drops an empty paragraph before an image paragraph', () => {
+    const img = messageSchema.node('image', { src: 'https://x.co/a.png' });
+    expect(serialize(doc(p(t('a')), p(), p(img)))).toBe(
+      'a\n\n![](https://x.co/a.png)'
+    );
+  });
+
+  it('silently drops a break-only paragraph before an image paragraph', () => {
+    const img = messageSchema.node('image', { src: 'https://x.co/a.png' });
+    expect(serialize(doc(p(t('a')), p(br()), p(img)))).toBe(
+      'a\n\n![](https://x.co/a.png)'
+    );
+  });
+
+  it('drops trailing breaks before an image paragraph', () => {
+    const img = messageSchema.node('image', { src: 'https://x.co/a.png' });
+    expect(serialize(doc(p(t('a'), br()), p(img)))).toBe(
+      'a\n\n![](https://x.co/a.png)'
+    );
+  });
+
+  it('normalizes a legacy glued signature image the same as the live editor', () => {
+    const parsed = new MessageMarkdownTransformer(messageSchema).parse(
+      'Thanks \\\nSivin | Chatwoot\n\n\\\n![](https://x.co/a.png)'
+    );
+    expect(serialize(parsed)).toBe(
+      'Thanks \\\nSivin | Chatwoot\n\n![](https://x.co/a.png)'
+    );
+  });
+});
+
+describe('round-trip', () => {
+  const parse = content =>
+    new MessageMarkdownTransformer(messageSchema).parse(content);
+
+  it('is stable for the empty-line-above-signature shape', () => {
+    const first = serialize(doc(p(t('hey')), p(), p(t('--')), p(t('Thanks'))));
+    expect(first).toBe('hey\n\n\\\n\\--\n\nThanks');
+    expect(serialize(parse(first))).toBe(first);
+  });
+
+  it('is stable for chained empty lines', () => {
+    const first = serialize(doc(p(t('a')), p(), p(), p(t('b'))));
+    expect(serialize(parse(first))).toBe(first);
+  });
+
+  it('is stable for a setext underline after a hard break', () => {
+    const first = serialize(doc(p(t('intro'), br(), t('--'))));
+    expect(serialize(parse(first))).toBe(first);
+  });
+
+  it('never renders a stray backslash or accidental heading, on any renderer', () => {
+    // Chatwoot dashboard config (breaks on, setext headings off) and a
+    // strict CommonMark config — the closest markdown-it proxy for the
+    // backend's cmark (setext headings ON, breaks off).
+    const frontend = new MarkdownIt({ breaks: true }).disable(['lheading']);
+    const strict = new MarkdownIt('commonmark');
+    const img = () => messageSchema.node('image', { src: 'https://x.co/a.png' });
+    const ul = () =>
+      messageSchema.node('bullet_list', null, [
+        messageSchema.node('list_item', null, [p(t('item'))]),
+      ]);
+
+    const leads = [
+      () => [p(t('hey'))],
+      () => [p(t('hey'), br(), br())],
+      () => [p(t('hey'), br(), t(' '), br())],
+    ];
+    const middles = [
+      () => [],
+      () => [p()],
+      () => [p(br())],
+      () => [p(), p(br())],
+      () => [p(t('   '))],
+    ];
+    const enders = [
+      () => [p(t('--'))],
+      () => [p(t('=='))],
+      () => [p(t('-'))],
+      () => [p(t('- '))],
+      () => [p(t('='))],
+      () => [p(t('  --'))],
+      () => [p(t('--', [mark('strong')]))],
+      () => [p(t('- pasted'))],
+      () => [ul()],
+      () => [p(img())],
+      () => [p(t('world'))],
+      () => [],
+    ];
+
+    leads.forEach(lead => {
+      middles.forEach(middle => {
+        enders.forEach(ender => {
+          const md = serialize(
+            doc(...lead(), ...middle(), ...ender(), p(t('tail')))
+          );
+          [frontend, strict].forEach(renderer => {
+            const html = renderer.render(md);
+            expect(html, md).not.toContain('\\');
+            expect(html, md).not.toContain('<h1');
+            expect(html, md).not.toContain('<h2');
+          });
+        });
+      });
+    });
+  });
+
+  it('is stable for trailing breaks chained into a signature', () => {
+    const first = serialize(
+      doc(p(t('sdsd'), br(), br()), p(), p(t('--')), p(t('Thanks')))
+    );
+    expect(first).toBe('sdsd\n\n\\\n\\\n\\\n\\--\n\nThanks');
+    expect(serialize(parse(first))).toBe(first);
   });
 });
 
@@ -184,12 +422,14 @@ describe('hard break × paragraph combinations', () => {
   });
 
   it('c6: trailing break then new paragraph', () => {
-    expect(serialize(doc(p(t('a'), br()), p(t('b'))))).toBe('a\n\nb');
+    expect(serialize(doc(p(t('a'), br()), p(t('b'))))).toBe('a\n\n\\\nb');
   });
 
   it('c7: bare bullet marker line then new paragraph', () => {
+    // "- " alone closes its line, so it is a setext underline hazard
+    // (`x\n- ` is <h2>x</h2> in cmark), not a list marker
     expect(serialize(doc(p(t('x'), br(), t('- ')), p(t('y'))))).toBe(
-      'x\n- \n\ny'
+      'x\\\n\\- \n\ny'
     );
   });
 
@@ -240,9 +480,9 @@ describe('hard break × paragraph combinations', () => {
     ).toBe(`<${URL}>\\\ntext after`);
   });
 
-  it('c13: trailing break after a link', () => {
+  it('c13: trailing break after a link at the end of the document', () => {
     expect(serialize(doc(p(t('check '), t(URL, [linkTo(URL)]), br())))).toBe(
-      `check <${URL}>\n`
+      `check <${URL}>`
     );
   });
 
@@ -262,8 +502,8 @@ describe('hard break × paragraph combinations', () => {
     ).toBe('**bold1\\\nbold2**');
   });
 
-  it('c16: thematic break syntax after a hard break', () => {
-    expect(serialize(doc(p(t('a'), br(), t('--- '))))).toBe('a\n--- ');
+  it('c16: setext underline with trailing space after a hard break', () => {
+    expect(serialize(doc(p(t('a'), br(), t('--- '))))).toBe('a\\\n\\--- ');
   });
 
   it('c17: heading syntax after a hard break', () => {
@@ -484,5 +724,65 @@ describe('article serializer', () => {
     const result = aSerialize(aDoc(table));
     expect(result).toContain('**bold**');
     expect(result).toContain(`[link](${URL})`);
+  });
+});
+
+// The serialized markdown must mean the same thing to a strict CommonMark
+// parser (setext headings ON, soft breaks NOT rendered as <br>) — exact
+// parsed HTML, not just absence of artifacts.
+describe('strict CommonMark render agreement', () => {
+  const strict = new MarkdownIt('commonmark');
+  const render = node => strict.render(serialize(node));
+
+  it('parses a hard break as <br>', () => {
+    expect(render(doc(p(t('one'), br(), t('two'))))).toBe('<p>one<br />\ntwo</p>\n');
+  });
+
+  it('parses an empty line as a leading <br> on the next paragraph', () => {
+    expect(render(doc(p(t('a')), p(), p(t('b'))))).toBe('<p>a</p>\n<p><br />\nb</p>\n');
+  });
+
+  it('parses two empty lines as two leading <br>s', () => {
+    expect(render(doc(p(t('a')), p(), p(), p(t('b'))))).toBe('<p>a</p>\n<p><br />\n<br />\nb</p>\n');
+  });
+
+  it('parses the escaped signature delimiter as literal text, not a heading', () => {
+    expect(render(doc(p(t('hey')), p(), p(t('--'))))).toBe('<p>hey</p>\n<p><br />\n--</p>\n');
+  });
+
+  it('parses a lone dash after a hard break as literal text, not a heading', () => {
+    expect(render(doc(p(t('a'), br(), t('-'))))).toBe('<p>a<br />\n-</p>\n');
+  });
+
+  it('parses an equals underline below an empty line as literal text', () => {
+    expect(render(doc(p(t('a')), p(), p(t('=='))))).toBe('<p>a</p>\n<p><br />\n==</p>\n');
+  });
+});
+
+// The article serializer shares the paragraph/hard_break serializers and the
+// splitTrailingBreaks normalization — pin the same break/underline behavior
+// on the article schema (P2: article coverage).
+describe('article serializer break handling', () => {
+  const aBr = () => fullSchema.node('hard_break');
+  const aStrong = () => fullSchema.marks.strong.create();
+
+  it('escapes a lone dash after a hard break', () => {
+    expect(aSerialize(aDoc(aP(aT('a'), aBr(), aT('-'))))).toBe('a\\\n\\-');
+  });
+
+  it('escapes the signature-style underline below an empty paragraph', () => {
+    expect(aSerialize(aDoc(aP(aT('a')), aP(), aP(aT('--'))))).toBe('a\n\n\\\n\\--');
+  });
+
+  it('splits trailing breaks into empty lines before the next paragraph', () => {
+    expect(aSerialize(aDoc(aP(aT('a'), aBr(), aBr()), aP(aT('b'))))).toBe('a\n\n\\\n\\\nb');
+  });
+
+  it('keeps bold dashes bold after a hard break', () => {
+    expect(aSerialize(aDoc(aP(aT('a'), aBr(), aT('--', [aStrong()]))))).toBe('a\\\n**--**');
+  });
+
+  it('detaches an indented underline with a blank line', () => {
+    expect(aSerialize(aDoc(aP(aT('a'), aBr(), aT('  =='))))).toBe('a\n\n  ==');
   });
 });

--- a/test/serializer.spec.js
+++ b/test/serializer.spec.js
@@ -92,6 +92,20 @@ describe('hard_break', () => {
     );
   });
 
+  // A whitespace-only marked node is expelled from the mark syntax on
+  // serialize, so it must not make an underline count as marked.
+  it('detaches an underline led by a bold space', () => {
+    expect(
+      serialize(doc(p(t('a'), br(), t(' ', [mark('strong')]), t('--'))))
+    ).toBe('a\n\n --');
+  });
+
+  it('escapes an underline trailed by a bold space', () => {
+    expect(
+      serialize(doc(p(t('a'), br(), t('--'), t(' ', [mark('strong')]))))
+    ).toBe('a\\\n\\-- ');
+  });
+
   it('keeps the backslash for a mid-sentence link that is not a list', () => {
     const result = serialize(
       doc(p(t('see'), br(), t('this '), t(URL, [mark('link', { href: URL })])))
@@ -242,6 +256,28 @@ describe('paragraph', () => {
     expect(serialize(doc(p(t('a')), p(), p(t('--', [mark('strong')]))))).toBe(
       'a\n\n\\\n**--**'
     );
+  });
+
+  it('detaches an underline led by a bold space below an empty line', () => {
+    expect(
+      serialize(doc(p(t('a')), p(), p(t(' ', [mark('strong')]), t('--'))))
+    ).toBe('a\n\n\n --');
+  });
+
+  it('detaches an equals underline led by an italic space below an empty line', () => {
+    expect(
+      serialize(doc(p(t('a')), p(), p(t(' ', [mark('em')]), t('=='))))
+    ).toBe('a\n\n\n ==');
+  });
+
+  it('escapes an underline trailed by a bold space below an empty line', () => {
+    expect(
+      serialize(doc(p(t('a')), p(), p(t('--'), t(' ', [mark('strong')]))))
+    ).toBe('a\n\n\\\n\\-- ');
+  });
+
+  it('detaches an indented equals underline below an empty line', () => {
+    expect(serialize(doc(p(t('a')), p(), p(t(' =='))))).toBe('a\n\n\n ==');
   });
 
   it('keeps a lone dash as a list marker when an image continues its line', () => {
@@ -756,6 +792,12 @@ describe('strict CommonMark render agreement', () => {
 
   it('parses an equals underline below an empty line as literal text', () => {
     expect(render(doc(p(t('a')), p(), p(t('=='))))).toBe('<p>a</p>\n<p><br />\n==</p>\n');
+  });
+
+  it('parses an underline led by an expelled bold space as literal text', () => {
+    expect(render(doc(p(t('a')), p(), p(t(' ', [mark('strong')]), t('--'))))).toBe(
+      '<p>a</p>\n<p>--</p>\n'
+    );
   });
 });
 


### PR DESCRIPTION
## Description
Replies composed with Enter / Shift+Enter no longer produce stray `\` characters or lose content to accidental setext headings. Empty lines and hard breaks are preserved as typed, and the `--` email signature separator survives an empty line above it.

### How to reproduce

* On an email inbox with a signature enabled, type a reply and press Enter, leaving an empty line above the `--` separator, then send. The email and dashboard bubble show a stray `\`, and the `--` line disappears.
* Press Shift+Enter multiple times before the signature. The empty lines are stripped.
* Add a `-`, `--`, or `==` line after Shift+Enter. In cmark-rendered channels, the text above it is interpreted as a heading.

### What changed

* Added a pre-serialization pass (`splitTrailingBreaks`) that reduces every empty visual line to one canonical shape, so Enter- and Shift+Enter-created empty lines serialize identically.
* Escape dash/equals underline lines after a break or empty line (`\--`) so cmark cannot interpret them as setext headings, including a lone `-`. Marked dashes (`**--**`) keep their existing mark syntax, which already prevents heading interpretation. Indented underlines remain detached behind a blank line.
* Treat a bare `#` line as an empty ATX heading instead of adding glue that leaves a literal `\`.
* The Shift+Enter keymap no longer inserts a space before the break. The space was a 2023 workaround to prevent link marks from being applied to the break node. The serializer now closes and reopens marks around breaks, so Shift+Enter can use the standard ProseMirror break insertion while bold and italic continue across the break as before.

